### PR TITLE
timeboxing: route ReviewCommit edits back to Refine and keep patch path non-blocking

### DIFF
--- a/src/fateforger/agents/timeboxing/README.md
+++ b/src/fateforger/agents/timeboxing/README.md
@@ -109,7 +109,7 @@ Stage 1: CollectConstraints -> StageGateOutput (frame_facts)
 Stage 2: CaptureInputs -> StageGateOutput (input_facts)
 Stage 3: Skeleton -> pre-generated draft if available, else synchronous draft -> markdown overview (presentation-first) + carry-forward seed `TBPlan` (no Stage 3 patch loop)
 Stage 4: Refine -> ensure TBPlan+baseline -> TBPatch -> apply_tb_ops() -> updated TBPlan -> advisory quality facts (0-4) -> sync to Google Calendar
-Stage 5: ReviewCommit -> final summary (no extra submit gate)
+Stage 5: ReviewCommit -> final summary; if user sends plan edits/corrections, route back to Stage 4 Refine in the same turn
 Undo action: undo latest sync transaction via session-backed state -> return to Refine
 Each stage response also includes deterministic Slack actions (Proceed when ready, plus Back/Redo/Cancel) that replace the same message when clicked.
 ```

--- a/src/fateforger/agents/timeboxing/agent.py
+++ b/src/fateforger/agents/timeboxing/agent.py
@@ -3663,7 +3663,6 @@ class TimeboxingFlowAgent(RoutedAgent):
             date=self._resolve_planning_date(session),
             timezone=session.tz_name or "UTC",
         )
-        await self._await_pending_constraint_extractions(session)
         constraints = await self._collect_constraints(session)
 
         # Use TBPlan path if available, fall back to legacy Timebox path

--- a/src/fateforger/agents/timeboxing/nodes/README.md
+++ b/src/fateforger/agents/timeboxing/nodes/README.md
@@ -28,7 +28,7 @@ GraphFlow node agents that implement the timeboxing stage machine. Each node is 
 | `StageCaptureInputsNode` | 2 | Builds input context (frame_facts + user tasks/priorities), calls the Stage 2 LLM, updates `session.input_facts`, and queues skeleton pre-generation when context is sufficient. |
 | `StageSkeletonNode` | 3 | Uses pre-generated skeleton when available; otherwise drafts synchronously. Produces markdown overview rendered via Slack `markdown` block and carries the prepared draft plan forward, but does not build sync baselines. |
 | `StageRefineNode` | 4 | Prepares `TBPlan` + remote baseline if missing, sends `TBPlan` + user feedback to `TimeboxPatcher`, applies `TBPatch` via `apply_tb_ops()`, then syncs current plan to Google Calendar. |
-| `StageReviewCommitNode` | 5 | Presents final plan summary. Undo remains available through Slack action routing (`ff_timebox_undo_submit`). |
+| `StageReviewCommitNode` | 5 | Presents final plan summary. When user sends schedule edits/corrections, `TransitionNode` routes the turn back to `StageRefineNode` so patching runs before another review. Undo remains available through Slack action routing (`ff_timebox_undo_submit`). |
 
 ### Base Class
 

--- a/src/fateforger/agents/timeboxing/stage_gating.py
+++ b/src/fateforger/agents/timeboxing/stage_gating.py
@@ -197,6 +197,7 @@ Decision rules
 - If the user supplies new details for the current stage, use action="provide_info".
 - If the user wants to move forward, use action="proceed".
 - If `stage_ready=true`, default to action="proceed" unless the user explicitly asks to stay/back/cancel or provides new scheduling facts.
+- If `current_stage=ReviewCommit` and the user provides corrections/changes/additions to the plan, use action="provide_info" (do not use proceed).
 - If the user pushes back on precision (for example "I don't need exact start times") and wants to keep moving, use action="proceed".
 - If the user asks to revisit earlier stages, use action="back" and set target_stage.
 - If the user asks to redo the current stage, use action="redo".


### PR DESCRIPTION
## Summary
- Route `ReviewCommit` edit/correction replies back to `Refine` in `TransitionNode`, so Stage 4 patching executes immediately.
- Remove blocking waits on pending constraint extraction in Stage 4 patch paths.
- Keep durable memory extraction/upsert as background-only behavior.
- Add regression tests for stage routing and non-blocking refine behavior.
- Update timeboxing docs to reflect Stage 5 -> Stage 4 iteration on edits.

Closes #26

## Scope
- `src/fateforger/agents/timeboxing/nodes/nodes.py`
- `src/fateforger/agents/timeboxing/agent.py`
- `src/fateforger/agents/timeboxing/stage_gating.py`
- `tests/unit/test_timeboxing_graphflow_state_machine.py`
- `tests/unit/test_phase4_rewiring.py`
- `src/fateforger/agents/timeboxing/README.md`
- `src/fateforger/agents/timeboxing/nodes/README.md`

## Notebook -> Artifact mapping
- Notebook mode decision: `code-only-mode` for this targeted orchestration bugfix.
- Notebook artifacts: none.
- Extracted artifacts:
  - ReviewCommit edit routing fix -> `nodes/nodes.py`
  - Non-blocking refine patch path -> `nodes/nodes.py`, `agent.py`
  - Decision prompt hardening -> `stage_gating.py`
  - Regression tests -> `tests/unit/test_timeboxing_graphflow_state_machine.py`, `tests/unit/test_phase4_rewiring.py`
  - Docs status update -> timeboxing README files

## Verification performed
- `poetry run pytest -q tests/unit/test_timeboxing_graphflow_state_machine.py tests/unit/test_phase4_rewiring.py`
- Result: `22 passed`

## Open Items
- To decide: none
- To do: manual Slack validation of Stage 5 edit -> Stage 4 patch loop in a live session
- Blocked by: none
