### PR TITLE
timeboxing: prompt-guided patch-first tools with background memory updates

### DIFF
--- a/src/fateforger/agents/timeboxing/README.md
+++ b/src/fateforger/agents/timeboxing/README.md
@@ -108,8 +108,8 @@ Stage 0: Date Confirmation (Slack buttons)
 Stage 1: CollectConstraints -> StageGateOutput (frame_facts)
 Stage 2: CaptureInputs -> StageGateOutput (input_facts)
 Stage 3: Skeleton -> pre-generated draft if available, else synchronous draft -> markdown overview (presentation-first) + carry-forward seed `TBPlan` (no Stage 3 patch loop)
-Stage 4: Refine -> ensure TBPlan+baseline -> TBPatch -> apply_tb_ops() -> updated TBPlan -> advisory quality facts (0-4) -> sync to Google Calendar
-Stage 5: ReviewCommit -> final summary (no extra submit gate)
+Stage 4: Refine -> prompt-guided tool orchestration (`timebox_patch_and_sync` primary, `memory_extract_and_upsert` optional background) -> advisory quality facts (0-4) -> sync to Google Calendar with explicit changed/unchanged reporting
+Stage 5: ReviewCommit -> final summary; user corrections route back to Stage 4 Refine in the same turn
 Undo action: undo latest sync transaction via session-backed state -> return to Refine
 Each stage response also includes deterministic Slack actions (Proceed when ready, plus Back/Redo/Cancel) that replace the same message when clicked.
 ```

--- a/src/fateforger/agents/timeboxing/nodes/README.md
+++ b/src/fateforger/agents/timeboxing/nodes/README.md
@@ -27,8 +27,8 @@ GraphFlow node agents that implement the timeboxing stage machine. Each node is 
 | `StageCollectConstraintsNode` | 1 | Builds constraint context (immovables + Notion + session constraints), calls the Stage 1 LLM via `stage_gating.py`, updates `session.frame_facts`. |
 | `StageCaptureInputsNode` | 2 | Builds input context (frame_facts + user tasks/priorities), calls the Stage 2 LLM, updates `session.input_facts`, and queues skeleton pre-generation when context is sufficient. |
 | `StageSkeletonNode` | 3 | Uses pre-generated skeleton when available; otherwise drafts synchronously. Produces markdown overview rendered via Slack `markdown` block and carries the prepared draft plan forward, but does not build sync baselines. |
-| `StageRefineNode` | 4 | Prepares `TBPlan` + remote baseline if missing, sends `TBPlan` + user feedback to `TimeboxPatcher`, applies `TBPatch` via `apply_tb_ops()`, then syncs current plan to Google Calendar. |
-| `StageReviewCommitNode` | 5 | Presents final plan summary. Undo remains available through Slack action routing (`ff_timebox_undo_submit`). |
+| `StageRefineNode` | 4 | Prepares `TBPlan` + remote baseline if missing, then delegates execution to prompt-guided tool orchestration (`timebox_patch_and_sync` as patch-critical primary action, optional background memory update). Appends explicit calendar changed/unchanged sync feedback. |
+| `StageReviewCommitNode` | 5 | Presents final plan summary. If user sends corrections, `TransitionNode` routes the same turn back to `StageRefineNode` so patching runs before another review. Undo remains available through Slack action routing (`ff_timebox_undo_submit`). |
 
 ### Base Class
 

--- a/src/fateforger/agents/timeboxing/stage_gating.py
+++ b/src/fateforger/agents/timeboxing/stage_gating.py
@@ -197,6 +197,7 @@ Decision rules
 - If the user supplies new details for the current stage, use action="provide_info".
 - If the user wants to move forward, use action="proceed".
 - If `stage_ready=true`, default to action="proceed" unless the user explicitly asks to stay/back/cancel or provides new scheduling facts.
+- If `current_stage=ReviewCommit` and the user provides corrections/changes/additions to the plan, use action="provide_info" (do not use proceed).
 - If the user pushes back on precision (for example "I don't need exact start times") and wants to keep moving, use action="proceed".
 - If the user asks to revisit earlier stages, use action="back" and set target_stage.
 - If the user asks to redo the current stage, use action="redo".

--- a/tests/unit/test_timeboxing_graphflow_state_machine.py
+++ b/tests/unit/test_timeboxing_graphflow_state_machine.py
@@ -9,6 +9,7 @@ from autogen_agentchat.messages import TextMessage
 
 from fateforger.agents.timeboxing.agent import Session, TimeboxingFlowAgent
 from fateforger.agents.timeboxing.flow_graph import build_timeboxing_graphflow
+from fateforger.agents.timeboxing.nodes.nodes import TransitionNode
 from fateforger.agents.timeboxing.patching import TimeboxPatcher
 from fateforger.agents.timeboxing.stage_gating import StageDecision, StageGateOutput, TimeboxingStage
 
@@ -153,3 +154,32 @@ async def test_graphflow_cancel_terminates_without_stage_run():
     assert out.content == "Okay—stopping this timeboxing session."
     assert session.thread_state == "canceled"
 
+
+@pytest.mark.asyncio
+async def test_transition_routes_reviewcommit_edits_back_to_refine():
+    agent = TimeboxingFlowAgent.__new__(TimeboxingFlowAgent)
+
+    async def _advance_stage(
+        _self,
+        session: Session,
+        *,
+        next_stage: TimeboxingStage,
+    ) -> None:
+        session.stage = next_stage
+
+    agent._advance_stage = types.MethodType(_advance_stage, agent)
+    session = Session(thread_ts="t1", channel_id="c1", user_id="u1", committed=True)
+    session.stage = TimeboxingStage.REVIEW_COMMIT
+
+    turn_init = types.SimpleNamespace(
+        turn=types.SimpleNamespace(
+            decision=StageDecision(action="provide_info"),
+            user_text="please add a lunch block and a buffer",
+        )
+    )
+    node = TransitionNode(orchestrator=agent, session=session, turn_init=turn_init)
+
+    await node.on_messages([], cancellation_token=types.SimpleNamespace())
+
+    assert session.stage == TimeboxingStage.REFINE
+    assert node.stage_user_message == "please add a lunch block and a buffer"

--- a/tests/unit/test_timeboxing_refine_tool_orchestration.py
+++ b/tests/unit/test_timeboxing_refine_tool_orchestration.py
@@ -1,0 +1,63 @@
+from __future__ import annotations
+
+import pytest
+
+pytest.importorskip("autogen_agentchat")
+
+from fateforger.agents.timeboxing.agent import TimeboxingFlowAgent
+from fateforger.agents.timeboxing.sync_engine import SyncOp, SyncOpType, SyncTransaction
+
+
+def test_select_refine_tool_intents_prioritizes_patch() -> None:
+    """Patch-critical intent should be selected ahead of memory intents."""
+    patch, memory = TimeboxingFlowAgent._select_refine_tool_intents(
+        [
+            (10, "memory", "remember this preference"),
+            (0, "patch", "add lunch and buffer"),
+            (0, "patch", "ignored second patch"),
+        ]
+    )
+    assert patch == "add lunch and buffer"
+    assert memory == "remember this preference"
+
+
+def test_summarize_sync_transaction_reports_unchanged_when_no_ops() -> None:
+    """Empty sync transactions should report unchanged calendar state."""
+    agent = TimeboxingFlowAgent.__new__(TimeboxingFlowAgent)
+    tx = SyncTransaction(status="committed")
+    outcome = TimeboxingFlowAgent._summarize_sync_transaction(agent, tx)
+    assert outcome.changed is False
+    assert outcome.created == 0
+    assert outcome.updated == 0
+    assert outcome.deleted == 0
+    assert outcome.failed == 0
+    assert "unchanged" in outcome.note.lower()
+
+
+def test_summarize_sync_transaction_reports_partial_counts() -> None:
+    """Partial sync should include per-op success/failure counters."""
+    agent = TimeboxingFlowAgent.__new__(TimeboxingFlowAgent)
+    tx = SyncTransaction(
+        ops=[
+            SyncOp(
+                op_type=SyncOpType.CREATE,
+                gcal_event_id="fftb1",
+                after_payload={},
+            ),
+            SyncOp(
+                op_type=SyncOpType.UPDATE,
+                gcal_event_id="fftb2",
+                after_payload={},
+            ),
+        ],
+        results=[{"ok": True}, {"ok": False}],
+        status="partial",
+    )
+    outcome = TimeboxingFlowAgent._summarize_sync_transaction(agent, tx)
+    assert outcome.status == "partial"
+    assert outcome.changed is True
+    assert outcome.created == 1
+    assert outcome.updated == 0
+    assert outcome.deleted == 0
+    assert outcome.failed == 1
+    assert "partially changed" in outcome.note.lower()


### PR DESCRIPTION
## Summary
- Add prompt-guided tool orchestration for Stage 4 execution with explicit priority selection:
  - patch-critical intent first (`timebox_patch_and_sync`)
  - memory intent second (`memory_extract_and_upsert`, non-blocking)
- Add structured calendar sync outcomes (`CalendarSyncOutcome`) with explicit changed/unchanged reporting.
- Route ReviewCommit corrections back to Refine in the same turn.
- Remove blocking pending-extraction wait on Stage 4 patch path.
- Add unit coverage for intent-priority selection and sync-outcome summaries.

Closes #28
Closes #26

## Scope
- `src/fateforger/agents/timeboxing/agent.py`
- `src/fateforger/agents/timeboxing/nodes/nodes.py`
- `src/fateforger/agents/timeboxing/stage_gating.py`
- `src/fateforger/agents/timeboxing/README.md`
- `src/fateforger/agents/timeboxing/nodes/README.md`
- `tests/unit/test_timeboxing_graphflow_state_machine.py`
- `tests/unit/test_phase4_rewiring.py`
- `tests/unit/test_timeboxing_refine_tool_orchestration.py`

## Notebook -> Artifact mapping
- Notebook mode decision: `code-only-mode`.
- Notebook artifacts: none.
- Extracted artifacts:
  - tool orchestration + priority selection -> `agent.py`
  - stage transition behavior -> `nodes/nodes.py`
  - decision policy prompt guard -> `stage_gating.py`
  - status docs + tests -> files listed above

## Verification performed
- `poetry run pytest -q tests/unit/test_timeboxing_graphflow_state_machine.py tests/unit/test_phase4_rewiring.py tests/unit/test_timeboxing_refine_tool_orchestration.py`
- Result: `24 passed`

## Open Items
- To decide: none
- To do: manual Slack live validation for Stage 5 edit -> Stage 4 patch loop with background memory updates
- Blocked by: none
