### PR TITLE
Issue #32: parallelize task-marshalling TickTick/Notion fetch paths

### DIFF
--- a/src/fateforger/agents/tasks/list_tools.py
+++ b/src/fateforger/agents/tasks/list_tools.py
@@ -2,15 +2,24 @@
 
 from __future__ import annotations
 
+import asyncio
 import json
 import logging
 import re
+import time
+from difflib import SequenceMatcher
 from enum import Enum
-from typing import Any
+from typing import Any, Literal
 
 from pydantic import BaseModel, Field, ValidationError
+from yarl import URL
 
-from fateforger.tools.ticktick_mcp import get_ticktick_mcp_url
+from fateforger.tools.ticktick_mcp import (
+    get_ticktick_mcp_url,
+    normalize_ticktick_mcp_url,
+    probe_ticktick_mcp_endpoint,
+    ticktick_localhost_fallback_urls,
+)
 
 
 logger = logging.getLogger(__name__)
@@ -81,15 +90,57 @@ class TickTickTask(BaseModel):
     project_id: str | None = None
 
 
+class TickTickPendingTask(BaseModel):
+    """Pending-task row enriched with project metadata."""
+
+    id: str
+    title: str
+    project_id: str | None = None
+    project_name: str | None = None
+
+
+class TickTickMentionCandidate(BaseModel):
+    """Scored task candidate for a specific mention."""
+
+    task_id: str
+    title: str
+    project_id: str | None = None
+    project_name: str | None = None
+    score: float
+    matched_query: str
+    match_type: str
+
+
+class TickTickMentionResolution(BaseModel):
+    """Resolution outcome for a single mention."""
+
+    mention: str
+    status: Literal["resolved", "ambiguous", "unresolved"]
+    expanded_queries: list[str]
+    resolved_task_id: str | None = None
+    resolved_title: str | None = None
+    resolved_project_id: str | None = None
+    resolved_project_name: str | None = None
+    candidates: list[TickTickMentionCandidate] = Field(default_factory=list)
+
+
 class TickTickListManager:
     """Coordinator that executes list-management operations via TickTick MCP."""
 
     def __init__(
-        self, *, server_url: str | None = None, timeout: float = 10.0, workbench: Any = None
+        self,
+        *,
+        server_url: str | None = None,
+        timeout: float = 10.0,
+        workbench: Any = None,
+        pending_snapshot_parallelism: int = 4,
     ) -> None:
-        self._server_url = (server_url or get_ticktick_mcp_url()).strip()
+        self._server_url = normalize_ticktick_mcp_url(
+            server_url or get_ticktick_mcp_url()
+        ).strip()
         self._timeout = timeout
         self._workbench = workbench
+        self._pending_snapshot_parallelism = max(1, int(pending_snapshot_parallelism))
 
     async def manage_ticktick_lists(
         self,
@@ -108,6 +159,8 @@ class TickTickListManager:
         normalized_create_if_missing = (
             True if create_if_missing is None else create_if_missing
         )
+        parsed_operation = self._safe_operation(operation)
+        parsed_model = self._safe_model(normalized_model)
         try:
             action = TickTickListActionInput(
                 operation=operation,
@@ -123,14 +176,79 @@ class TickTickListManager:
         except ValidationError as exc:
             return TickTickListActionResult(
                 ok=False,
-                operation=TickTickListOperation.SHOW_LISTS,
-                model=TickTickListModel.PROJECT,
+                operation=parsed_operation,
+                model=parsed_model,
                 errors=[f"invalid_input: {exc.errors()}"],
                 summary="Invalid list-management input.",
             ).model_dump(mode="json")
 
         result = await self.execute(action)
         return result.model_dump(mode="json")
+
+    async def resolve_ticktick_task_mentions(
+        self,
+        mentions: list[str] | None,
+        expansion_queries: list[str] | None,
+        max_candidates_per_mention: int | None,
+        min_score: float | None,
+        ambiguity_gap: float | None,
+        include_all_projects: bool | None,
+    ) -> dict[str, Any]:
+        """Resolve task mentions against exhaustive cross-project candidates."""
+        clean_mentions = self._clean_items(mentions or [])
+        if not clean_mentions:
+            return {
+                "ok": False,
+                "summary": "No task mentions were provided.",
+                "results": [],
+                "status_counts": {"resolved": 0, "ambiguous": 0, "unresolved": 0},
+            }
+
+        normalized_max_candidates = 5 if max_candidates_per_mention is None else max(
+            1, max_candidates_per_mention
+        )
+        normalized_min_score = 0.45 if min_score is None else max(0.0, min(1.0, min_score))
+        normalized_ambiguity_gap = (
+            0.08 if ambiguity_gap is None else max(0.0, min(1.0, ambiguity_gap))
+        )
+        use_all_projects = True if include_all_projects is None else include_all_projects
+        rows = (
+            await self.list_all_pending_tasks()
+            if use_all_projects
+            else await self.list_pending_tasks(limit=200, per_project_limit=20)
+        )
+
+        resolutions: list[TickTickMentionResolution] = []
+        counts = {"resolved": 0, "ambiguous": 0, "unresolved": 0}
+        normalized_expansions = self._clean_items(expansion_queries or [])
+        for mention in clean_mentions:
+            expanded_queries = self._build_query_expansions(mention, normalized_expansions)
+            candidates = self._score_mention_candidates(
+                mention=mention,
+                expanded_queries=expanded_queries,
+                rows=rows,
+                min_score=normalized_min_score,
+            )[:normalized_max_candidates]
+            resolution = self._classify_mention_resolution(
+                mention=mention,
+                expanded_queries=expanded_queries,
+                candidates=candidates,
+                ambiguity_gap=normalized_ambiguity_gap,
+            )
+            counts[resolution.status] += 1
+            resolutions.append(resolution)
+
+        return {
+            "ok": True,
+            "summary": (
+                f"Resolved {counts['resolved']}, ambiguous {counts['ambiguous']}, "
+                f"unresolved {counts['unresolved']} mention(s)."
+            ),
+            "exhausted": len(resolutions) == len(clean_mentions),
+            "mention_count": len(clean_mentions),
+            "status_counts": counts,
+            "results": [resolution.model_dump(mode="json") for resolution in resolutions],
+        }
 
     async def execute(self, action: TickTickListActionInput) -> TickTickListActionResult:
         """Dispatch a validated list-management action."""
@@ -231,6 +349,24 @@ class TickTickListManager:
             )
 
         if action.operation == TickTickListOperation.SHOW_LIST_ITEMS:
+            if not action.list_id and not action.list_name:
+                rows = await self.list_all_pending_tasks()
+                items = [
+                    {
+                        "id": row.id,
+                        "title": row.title,
+                        "project_id": row.project_id,
+                        "project_name": row.project_name,
+                    }
+                    for row in rows
+                ]
+                return TickTickListActionResult(
+                    ok=True,
+                    operation=action.operation,
+                    model=action.model,
+                    summary=f"Found {len(items)} pending task(s) across all projects.",
+                    data={"list_name": "__all__", "items": items},
+                )
             project, _, errors, ambiguous = await self._resolve_project(
                 action, allow_create=False
             )
@@ -638,6 +774,78 @@ class TickTickListManager:
         text = await self._call_tool("get_project_tasks", {"project_id": project_id})
         return self._parse_tasks(text)
 
+    async def list_pending_tasks(
+        self, *, limit: int = 12, per_project_limit: int = 4
+    ) -> list[TickTickPendingTask]:
+        """Return a bounded pending-task snapshot across projects."""
+        started_at = time.perf_counter()
+        try:
+            projects = await self._list_projects()
+        except Exception as exc:
+            logger.warning(
+                "TickTick pending snapshot unavailable; returning empty set (%s: %s)",
+                type(exc).__name__,
+                exc,
+            )
+            return []
+        if not projects:
+            return []
+        rows: list[TickTickPendingTask] = []
+        task_batches = await self._list_project_task_batches(projects)
+        for project, task_batch in zip(projects, task_batches):
+            if isinstance(task_batch, Exception):
+                exc = task_batch
+                logger.warning(
+                    "TickTick project task fetch failed; skipping project",
+                    extra={
+                        "event": "ticktick_pending_snapshot_project_failed",
+                        "project_id": project.id,
+                        "project_name": project.name,
+                        "error_type": type(exc).__name__,
+                        "error": str(exc),
+                    },
+                )
+                continue
+            tasks = task_batch
+            for task in tasks[:per_project_limit]:
+                rows.append(
+                    TickTickPendingTask(
+                        id=task.id,
+                        title=task.title,
+                        project_id=project.id,
+                        project_name=project.name,
+                    )
+                )
+                if len(rows) >= limit:
+                    logger.info(
+                        "TickTick pending snapshot completed",
+                        extra={
+                            "event": "ticktick_pending_snapshot_latency",
+                            "project_count": len(projects),
+                            "row_count": len(rows),
+                            "elapsed_ms": round(
+                                (time.perf_counter() - started_at) * 1000.0, 3
+                            ),
+                        },
+                    )
+                    return rows
+        logger.info(
+            "TickTick pending snapshot completed",
+            extra={
+                "event": "ticktick_pending_snapshot_latency",
+                "project_count": len(projects),
+                "row_count": len(rows),
+                "elapsed_ms": round((time.perf_counter() - started_at) * 1000.0, 3),
+            },
+        )
+        return rows
+
+    async def list_all_pending_tasks(self) -> list[TickTickPendingTask]:
+        """Return all pending tasks across all projects."""
+        # High ceiling keeps this bounded for safety while effectively "all"
+        # for normal TickTick workspaces.
+        return await self.list_pending_tasks(limit=10_000, per_project_limit=10_000)
+
     async def _delete_items(
         self, *, project_id: str, task_ids: list[str]
     ) -> tuple[int, list[str]]:
@@ -703,6 +911,142 @@ class TickTickListManager:
         deduped = list(dict.fromkeys(resolved))
         return deduped, skipped, errors
 
+    def _build_query_expansions(
+        self, mention: str, expansion_queries: list[str]
+    ) -> list[str]:
+        queries: list[str] = []
+        seen: set[str] = set()
+
+        def _add(value: str) -> None:
+            clean = " ".join((value or "").split()).strip()
+            key = self._normalize(clean)
+            if not clean or not key or key in seen:
+                return
+            seen.add(key)
+            queries.append(clean)
+
+        _add(mention)
+        for query in expansion_queries:
+            _add(query)
+
+        tokens = re.findall(r"[A-Za-z0-9]+", mention)
+        long_tokens = [token for token in tokens if len(token) >= 4]
+        for token in long_tokens:
+            _add(token)
+        if len(tokens) >= 2:
+            _add(" ".join(tokens))
+            _add(" ".join(tokens[:2]))
+            _add(" ".join(tokens[-2:]))
+        return queries
+
+    def _score_mention_candidates(
+        self,
+        *,
+        mention: str,
+        expanded_queries: list[str],
+        rows: list[TickTickPendingTask],
+        min_score: float,
+    ) -> list[TickTickMentionCandidate]:
+        best_by_task: dict[str, TickTickMentionCandidate] = {}
+        for row in rows:
+            if not row.id or not row.title:
+                continue
+            best_score = -1.0
+            best_query = ""
+            best_match_type = "none"
+            for query in expanded_queries:
+                score, match_type = self._score_title_match(row.title, query)
+                if score > best_score:
+                    best_score = score
+                    best_query = query
+                    best_match_type = match_type
+            if best_score < min_score:
+                continue
+            candidate = TickTickMentionCandidate(
+                task_id=row.id,
+                title=row.title,
+                project_id=row.project_id,
+                project_name=row.project_name,
+                score=round(best_score, 4),
+                matched_query=best_query,
+                match_type=best_match_type,
+            )
+            existing = best_by_task.get(row.id)
+            if existing is None or candidate.score > existing.score:
+                best_by_task[row.id] = candidate
+
+        return sorted(
+            best_by_task.values(),
+            key=lambda candidate: (-candidate.score, candidate.title.lower()),
+        )
+
+    def _score_title_match(self, title: str, query: str) -> tuple[float, str]:
+        normalized_title = self._normalize(title)
+        normalized_query = self._normalize(query)
+        if not normalized_title or not normalized_query:
+            return 0.0, "none"
+        if normalized_title == normalized_query:
+            return 1.0, "exact"
+        if normalized_query in normalized_title:
+            return 0.9, "contains"
+        if normalized_title in normalized_query and len(normalized_title) >= 4:
+            return 0.86, "superset"
+
+        title_tokens = set(normalized_title.split())
+        query_tokens = set(normalized_query.split())
+        overlap = title_tokens & query_tokens
+        jaccard = (
+            len(overlap) / len(title_tokens | query_tokens)
+            if title_tokens and query_tokens
+            else 0.0
+        )
+        seq = SequenceMatcher(None, normalized_title, normalized_query).ratio()
+        score = max(seq, jaccard)
+        if query_tokens and query_tokens.issubset(title_tokens):
+            score = max(score, 0.82)
+        if overlap and len(overlap) >= 2:
+            score = max(score, 0.78)
+        return score, "fuzzy"
+
+    def _classify_mention_resolution(
+        self,
+        *,
+        mention: str,
+        expanded_queries: list[str],
+        candidates: list[TickTickMentionCandidate],
+        ambiguity_gap: float,
+    ) -> TickTickMentionResolution:
+        if not candidates:
+            return TickTickMentionResolution(
+                mention=mention,
+                status="unresolved",
+                expanded_queries=expanded_queries,
+                candidates=[],
+            )
+
+        best = candidates[0]
+        second = candidates[1] if len(candidates) > 1 else None
+        resolved = best.score >= 0.9 and (
+            second is None or (best.score - second.score) >= ambiguity_gap
+        )
+        if resolved:
+            return TickTickMentionResolution(
+                mention=mention,
+                status="resolved",
+                expanded_queries=expanded_queries,
+                resolved_task_id=best.task_id,
+                resolved_title=best.title,
+                resolved_project_id=best.project_id,
+                resolved_project_name=best.project_name,
+                candidates=candidates,
+            )
+        return TickTickMentionResolution(
+            mention=mention,
+            status="ambiguous",
+            expanded_queries=expanded_queries,
+            candidates=candidates,
+        )
+
     def _match_tasks_by_title(
         self, tasks: list[TickTickTask], selector: str
     ) -> list[TickTickTask]:
@@ -730,6 +1074,25 @@ class TickTickListManager:
             return None, contains
         return None, []
 
+    async def _list_project_task_batches(
+        self, projects: list[TickTickProject]
+    ) -> list[list[TickTickTask] | Exception]:
+        semaphore = asyncio.Semaphore(self._pending_snapshot_parallelism)
+        batches: list[list[TickTickTask] | Exception | None] = [None] * len(projects)
+
+        async def _fetch(index: int, project: TickTickProject) -> None:
+            async with semaphore:
+                try:
+                    tasks = await self._list_project_tasks(project.id)
+                    batches[index] = tasks
+                except Exception as exc:
+                    batches[index] = exc
+
+        await asyncio.gather(
+            *(_fetch(index, project) for index, project in enumerate(projects))
+        )
+        return [batch if batch is not None else [] for batch in batches]
+
     async def _call_tool(self, name: str, arguments: dict[str, Any]) -> str:
         workbench = self._ensure_workbench()
         result = await workbench.call_tool(name, arguments=arguments)
@@ -750,6 +1113,30 @@ class TickTickListManager:
             ) from exc
         if not self._server_url:
             raise RuntimeError("TickTick MCP URL is not configured.")
+        ok, reason = probe_ticktick_mcp_endpoint(
+            self._server_url, connect_timeout_s=min(self._timeout, 1.5)
+        )
+        if not ok:
+            parsed = URL(self._server_url)
+            if parsed.host == "ticktick-mcp":
+                for fallback in ticktick_localhost_fallback_urls(self._server_url):
+                    fallback_ok, fallback_reason = probe_ticktick_mcp_endpoint(
+                        fallback, connect_timeout_s=min(self._timeout, 1.5)
+                    )
+                    if not fallback_ok:
+                        reason = fallback_reason or reason
+                        continue
+                    logger.warning(
+                        "TickTick MCP endpoint '%s' is unavailable (%s); using '%s'.",
+                        self._server_url,
+                        reason,
+                        fallback,
+                    )
+                    self._server_url = fallback
+                    ok = True
+                    break
+            if not ok:
+                raise RuntimeError(reason or "TickTick MCP endpoint is unavailable.")
         params = StreamableHttpServerParams(url=self._server_url, timeout=self._timeout)
         self._workbench = McpWorkbench(params)
         return self._workbench
@@ -900,10 +1287,24 @@ class TickTickListManager:
 
     @staticmethod
     def _extract_first_id(text: str) -> str | None:
-        match = re.search(r"ID:\s*([A-Za-z0-9]+)", text)
+        match = re.search(r"ID:\s*([A-Za-z0-9_-]+)", text)
         if match:
             return match.group(1).strip()
         return None
+
+    @staticmethod
+    def _safe_operation(value: str) -> TickTickListOperation:
+        try:
+            return TickTickListOperation(value)
+        except Exception:
+            return TickTickListOperation.SHOW_LISTS
+
+    @staticmethod
+    def _safe_model(value: str) -> TickTickListModel:
+        try:
+            return TickTickListModel(value)
+        except Exception:
+            return TickTickListModel.PROJECT
 
     @staticmethod
     def _parse_created_count(text: str) -> int | None:
@@ -958,6 +1359,8 @@ class TickTickListManager:
 
 
 __all__ = [
+    "TickTickMentionCandidate",
+    "TickTickMentionResolution",
     "TickTickListActionInput",
     "TickTickListActionResult",
     "TickTickListManager",

--- a/src/fateforger/agents/tasks/notion_sprint_tools.py
+++ b/src/fateforger/agents/tasks/notion_sprint_tools.py
@@ -2,15 +2,25 @@
 
 from __future__ import annotations
 
+import asyncio
 import json
 import logging
+import re
+import time
 from dataclasses import dataclass
 from hashlib import sha256
 from typing import Any, Sequence
 
 from pydantic import BaseModel, Field
+from yarl import URL
 
-from fateforger.tools.notion_mcp import get_notion_mcp_headers, get_notion_mcp_url
+from fateforger.tools.mcp_url_validation import rewrite_mcp_host
+from fateforger.tools.notion_mcp import (
+    get_notion_mcp_headers,
+    get_notion_mcp_url,
+    normalize_notion_mcp_url,
+    probe_notion_mcp_endpoint,
+)
 
 
 logger = logging.getLogger(__name__)
@@ -44,45 +54,125 @@ class NotionSprintManager:
     """Executes sprint-focused Notion operations via MCP tools."""
 
     def __init__(
-        self, *, server_url: str | None = None, timeout: float = 10.0, workbench: Any = None
+        self,
+        *,
+        server_url: str | None = None,
+        timeout: float = 10.0,
+        workbench: Any = None,
+        default_data_source_url: str | None = None,
+        default_database_id: str | None = None,
+        default_data_source_urls: Sequence[str] | None = None,
+        default_database_ids: Sequence[str] | None = None,
+        default_source_resolution_parallelism: int = 4,
+        dry_run_patch_parallelism: int = 4,
     ) -> None:
-        self._server_url = (server_url or get_notion_mcp_url()).strip()
+        self._server_url = normalize_notion_mcp_url(
+            server_url or get_notion_mcp_url()
+        ).strip()
         self._timeout = timeout
         self._workbench = workbench
+        self._default_source_resolution_parallelism = max(
+            1, int(default_source_resolution_parallelism)
+        )
+        self._dry_run_patch_parallelism = max(1, int(dry_run_patch_parallelism))
+        self._default_data_source_url = (default_data_source_url or "").strip()
+        self._default_database_id = (default_database_id or "").strip()
+        initial_data_source_urls = list(default_data_source_urls or [])
+        if self._default_data_source_url:
+            initial_data_source_urls.append(self._default_data_source_url)
+        self._default_data_source_urls = self._dedupe_keep_order(
+            [value.strip() for value in initial_data_source_urls if str(value).strip()]
+        )
+
+        initial_database_ids = list(default_database_ids or [])
+        if self._default_database_id:
+            initial_database_ids.append(self._default_database_id)
+        self._default_database_ids = self._dedupe_keep_order(
+            [value.strip() for value in initial_database_ids if str(value).strip()]
+        )
 
     async def find_sprint_items(
         self,
         query: str,
-        data_source_url: str,
+        data_source_url: str | None,
         filters: dict[str, Any] | None,
         limit: int | None,
     ) -> dict[str, Any]:
         """Search sprint records from a specific Notion data source."""
         normalized_limit = 25 if limit is None else limit
-        arguments: dict[str, Any] = {
-            "query": query,
-            "query_type": "internal",
-            "data_source_url": data_source_url,
-        }
-        if filters:
-            arguments["filters"] = filters
+        resolved_data_source_urls = await self._resolve_data_source_urls(data_source_url)
+        if not resolved_data_source_urls:
+            return {
+                "ok": False,
+                "query": query,
+                "results": [],
+                "count": 0,
+                "raw": {},
+                "error": (
+                    "No Notion sprint data source is configured. "
+                    "Set NOTION_SPRINT_DATA_SOURCE_URL(S) or NOTION_SPRINT_DB_ID(S), "
+                    "or pass data_source_url explicitly."
+                ),
+            }
+        aggregated_results: list[Any] = []
+        raw_payloads: dict[str, Any] = {}
+        source_errors: list[str] = []
+        for resolved_data_source_url in resolved_data_source_urls:
+            arguments: dict[str, Any] = {
+                "query": query,
+                "query_type": "internal",
+                "data_source_url": resolved_data_source_url,
+            }
+            if filters:
+                arguments["filters"] = filters
+            try:
+                result = await self._call_tool_alias(SEARCH_TOOL_ALIASES, arguments)
+                payload = self._decode_payload(result)
+                raw_payloads[resolved_data_source_url] = payload
+            except Exception as exc:
+                source_errors.append(
+                    f"{resolved_data_source_url}: {type(exc).__name__}: {exc}"
+                )
+                continue
 
-        result = await self._call_tool_alias(SEARCH_TOOL_ALIASES, arguments)
-        payload = self._decode_payload(result)
+            if isinstance(payload, dict) and isinstance(payload.get("results"), list):
+                source_results = payload["results"]
+            elif isinstance(payload, list):
+                source_results = payload
+            else:
+                source_results = []
+            for source_result in source_results:
+                if isinstance(source_result, dict):
+                    enriched = dict(source_result)
+                    enriched.setdefault("data_source_url", resolved_data_source_url)
+                    aggregated_results.append(enriched)
+                else:
+                    aggregated_results.append(source_result)
 
-        if isinstance(payload, dict) and isinstance(payload.get("results"), list):
-            results = payload["results"][: max(0, normalized_limit)]
-        elif isinstance(payload, list):
-            results = payload[: max(0, normalized_limit)]
-        else:
-            results = []
+        results = aggregated_results[: max(0, normalized_limit)]
+        if not results and source_errors:
+            return {
+                "ok": False,
+                "query": query,
+                "results": [],
+                "count": 0,
+                "raw": raw_payloads,
+                "errors": source_errors,
+                "data_source_urls": resolved_data_source_urls,
+                "error": "All configured Notion sprint sources failed.",
+            }
 
         return {
             "ok": True,
             "query": query,
+            "data_source_url": (
+                resolved_data_source_urls[0] if len(resolved_data_source_urls) == 1 else None
+            ),
+            "data_source_urls": resolved_data_source_urls,
             "results": results,
             "count": len(results),
-            "raw": payload,
+            "raw": raw_payloads,
+            "errors": source_errors,
         }
 
     async def link_sprint_subtasks(
@@ -219,6 +309,183 @@ class NotionSprintManager:
             verified=verified,
         ).model_dump(mode="json")
 
+    async def patch_sprint_event(
+        self,
+        *,
+        page_id: str,
+        search_text: str,
+        replace_text: str,
+        langdiff_plan_json: str | None,
+        dry_run: bool | None,
+        match_threshold: float | None,
+        match_distance: int | None,
+    ) -> dict[str, Any]:
+        """Opinionated single-event patch command for sprint records."""
+        result = await self.patch_sprint_page_content(
+            page_id=page_id,
+            search_text=search_text,
+            replace_text=replace_text,
+            langdiff_plan_json=langdiff_plan_json,
+            dry_run=dry_run,
+            match_threshold=match_threshold,
+            match_distance=match_distance,
+        )
+        return {
+            "ok": bool(result.get("ok")),
+            "mode": result.get("mode"),
+            "page_id": page_id,
+            "summary": result.get("summary", ""),
+            "result": result,
+        }
+
+    async def patch_sprint_events(
+        self,
+        *,
+        page_ids: list[str] | None,
+        query: str | None,
+        data_source_url: str | None,
+        filters: dict[str, Any] | None,
+        limit: int | None,
+        search_text: str,
+        replace_text: str,
+        langdiff_plan_json: str | None,
+        dry_run: bool | None,
+        match_threshold: float | None,
+        match_distance: int | None,
+        stop_on_error: bool | None,
+    ) -> dict[str, Any]:
+        """Opinionated bulk patch command for sprint records."""
+        started_at = time.perf_counter()
+        selected_page_ids: list[str] = []
+        for raw_page_id in (page_ids or []):
+            normalized = str(raw_page_id).strip()
+            if normalized:
+                selected_page_ids.append(normalized)
+
+        selection_mode = "explicit"
+        if not selected_page_ids:
+            normalized_query = (query or "").strip()
+            if not normalized_query:
+                return {
+                    "ok": False,
+                    "summary": (
+                        "No target events provided. Pass page_ids, or provide query "
+                        "with optional filters/limit to select sprint events first."
+                    ),
+                    "selection_mode": "none",
+                    "attempted": 0,
+                    "patched": 0,
+                    "failed": 0,
+                    "results": [],
+                }
+            search = await self.find_sprint_items(
+                query=normalized_query,
+                data_source_url=data_source_url,
+                filters=filters,
+                limit=limit,
+            )
+            if not search.get("ok"):
+                return {
+                    "ok": False,
+                    "summary": "Could not search sprint events before patching.",
+                    "selection_mode": "search",
+                    "search": search,
+                    "attempted": 0,
+                    "patched": 0,
+                    "failed": 0,
+                    "results": [],
+                }
+            selected_page_ids = self._extract_page_ids(search.get("results"))
+            selection_mode = "search"
+            if not selected_page_ids:
+                return {
+                    "ok": False,
+                    "summary": "Search returned no patchable sprint event IDs.",
+                    "selection_mode": selection_mode,
+                    "search_count": int(search.get("count", 0)),
+                    "attempted": 0,
+                    "patched": 0,
+                    "failed": 0,
+                    "results": [],
+                }
+
+        normalized_stop_on_error = True if stop_on_error is None else stop_on_error
+        per_event_results: list[dict[str, Any]] = []
+        patched = 0
+        failed = 0
+
+        use_parallel_dry_run = (
+            bool(dry_run)
+            and not normalized_stop_on_error
+            and self._dry_run_patch_parallelism > 1
+            and len(selected_page_ids) > 1
+        )
+        if use_parallel_dry_run:
+            per_event_results = await self._run_parallel_dry_run_previews(
+                selected_page_ids=selected_page_ids,
+                search_text=search_text,
+                replace_text=replace_text,
+                langdiff_plan_json=langdiff_plan_json,
+                dry_run=dry_run,
+                match_threshold=match_threshold,
+                match_distance=match_distance,
+            )
+            patched = sum(1 for row in per_event_results if bool(row.get("ok")))
+            failed = len(per_event_results) - patched
+        else:
+            for page_id in selected_page_ids:
+                patch_result = await self.patch_sprint_page_content(
+                    page_id=page_id,
+                    search_text=search_text,
+                    replace_text=replace_text,
+                    langdiff_plan_json=langdiff_plan_json,
+                    dry_run=dry_run,
+                    match_threshold=match_threshold,
+                    match_distance=match_distance,
+                )
+                event_ok = bool(patch_result.get("ok"))
+                if event_ok:
+                    patched += 1
+                else:
+                    failed += 1
+                per_event_results.append(
+                    {
+                        "page_id": page_id,
+                        "ok": event_ok,
+                        "mode": patch_result.get("mode"),
+                        "summary": patch_result.get("summary"),
+                        "result": patch_result,
+                    }
+                )
+                if failed > 0 and normalized_stop_on_error:
+                    break
+
+        attempted = len(per_event_results)
+        logger.info(
+            "Notion sprint bulk patch completed",
+            extra={
+                "event": "notion_sprint_bulk_patch_latency",
+                "attempted": attempted,
+                "patched": patched,
+                "failed": failed,
+                "selection_mode": selection_mode,
+                "parallel_dry_run": use_parallel_dry_run,
+                "elapsed_ms": round((time.perf_counter() - started_at) * 1000.0, 3),
+            },
+        )
+        return {
+            "ok": failed == 0,
+            "summary": (
+                f"Patched {patched}/{attempted} sprint event(s)"
+                + (" (stopped on first error)." if failed and normalized_stop_on_error else ".")
+            ),
+            "selection_mode": selection_mode,
+            "attempted": attempted,
+            "patched": patched,
+            "failed": failed,
+            "results": per_event_results,
+        }
+
     async def _fetch_page_text(self, page_id: str) -> str:
         result = await self._call_tool_alias(FETCH_TOOL_ALIASES, {"id": page_id})
         payload = self._decode_payload(result)
@@ -230,6 +497,104 @@ class NotionSprintManager:
                 if isinstance(value, str):
                     return value
         return str(payload)
+
+    async def _resolve_data_source_urls(
+        self, provided_data_source_url: str | None
+    ) -> list[str]:
+        started_at = time.perf_counter()
+        explicit = (provided_data_source_url or "").strip()
+        if explicit:
+            return [explicit]
+        if self._default_data_source_urls:
+            return list(self._default_data_source_urls)
+        if not self._default_database_ids:
+            return []
+
+        extracted_urls: list[str] = []
+        semaphore = asyncio.Semaphore(self._default_source_resolution_parallelism)
+        batches: list[list[str] | None] = [None] * len(self._default_database_ids)
+
+        async def _resolve(index: int, database_id: str) -> None:
+            async with semaphore:
+                try:
+                    result = await self._call_tool_alias(FETCH_TOOL_ALIASES, {"id": database_id})
+                    payload = self._decode_payload(result)
+                    batches[index] = self._extract_data_source_urls(payload)
+                except Exception as exc:
+                    logger.warning(
+                        "Notion sprint data-source resolution failed for database id",
+                        extra={
+                            "event": "notion_sprint_default_db_resolution_failed",
+                            "database_id": database_id,
+                            "error_type": type(exc).__name__,
+                            "error": str(exc),
+                        },
+                    )
+                    batches[index] = []
+
+        await asyncio.gather(
+            *(
+                _resolve(index, database_id)
+                for index, database_id in enumerate(self._default_database_ids)
+            )
+        )
+        for batch in batches:
+            extracted_urls.extend(batch or [])
+
+        self._default_data_source_urls = self._dedupe_keep_order(
+            [value for value in extracted_urls if value]
+        )
+        logger.info(
+            "Notion sprint source resolution completed",
+            extra={
+                "event": "notion_sprint_source_resolution_latency",
+                "database_count": len(self._default_database_ids),
+                "resolved_count": len(self._default_data_source_urls),
+                "elapsed_ms": round((time.perf_counter() - started_at) * 1000.0, 3),
+            },
+        )
+        return list(self._default_data_source_urls)
+
+    async def _run_parallel_dry_run_previews(
+        self,
+        *,
+        selected_page_ids: list[str],
+        search_text: str,
+        replace_text: str,
+        langdiff_plan_json: str | None,
+        dry_run: bool | None,
+        match_threshold: float | None,
+        match_distance: int | None,
+    ) -> list[dict[str, Any]]:
+        semaphore = asyncio.Semaphore(self._dry_run_patch_parallelism)
+        results: list[dict[str, Any] | None] = [None] * len(selected_page_ids)
+
+        async def _preview(index: int, page_id: str) -> None:
+            async with semaphore:
+                patch_result = await self.patch_sprint_page_content(
+                    page_id=page_id,
+                    search_text=search_text,
+                    replace_text=replace_text,
+                    langdiff_plan_json=langdiff_plan_json,
+                    dry_run=dry_run,
+                    match_threshold=match_threshold,
+                    match_distance=match_distance,
+                )
+                results[index] = {
+                    "page_id": page_id,
+                    "ok": bool(patch_result.get("ok")),
+                    "mode": patch_result.get("mode"),
+                    "summary": patch_result.get("summary"),
+                    "result": patch_result,
+                }
+
+        await asyncio.gather(
+            *(
+                _preview(index, page_id)
+                for index, page_id in enumerate(selected_page_ids)
+            )
+        )
+        return [row if row is not None else {} for row in results]
 
     async def _call_tool_alias(
         self, aliases: Sequence[str], arguments: dict[str, Any]
@@ -266,6 +631,31 @@ class NotionSprintManager:
             ) from exc
         if not self._server_url:
             raise RuntimeError("Notion MCP URL is not configured.")
+        ok, reason = probe_notion_mcp_endpoint(
+            self._server_url, connect_timeout_s=min(self._timeout, 1.5)
+        )
+        if not ok:
+            parsed = URL(self._server_url)
+            if parsed.host == "notion-mcp":
+                fallback = rewrite_mcp_host(
+                    self._server_url, "localhost", default_path="/mcp"
+                )
+                fallback_ok, fallback_reason = probe_notion_mcp_endpoint(
+                    fallback, connect_timeout_s=min(self._timeout, 1.5)
+                )
+                if fallback_ok:
+                    logger.warning(
+                        "Notion MCP endpoint '%s' is unavailable (%s); using '%s'.",
+                        self._server_url,
+                        reason,
+                        fallback,
+                    )
+                    self._server_url = fallback
+                    ok = True
+                else:
+                    reason = fallback_reason or reason
+            if not ok:
+                raise RuntimeError(reason or "Notion MCP endpoint is unavailable.")
         params = StreamableHttpServerParams(
             url=self._server_url,
             headers=get_notion_mcp_headers(),
@@ -285,6 +675,44 @@ class NotionSprintManager:
             return json.loads(text)
         except Exception:
             return text
+
+    @staticmethod
+    def _extract_page_ids(results: Any) -> list[str]:
+        if not isinstance(results, list):
+            return []
+        page_ids: list[str] = []
+        for item in results:
+            if not isinstance(item, dict):
+                continue
+            for key in ("id", "page_id"):
+                raw = item.get(key)
+                if isinstance(raw, str) and raw.strip():
+                    page_ids.append(raw.strip())
+                    break
+        return page_ids
+
+    @staticmethod
+    def _extract_data_source_urls(payload: str | dict | list) -> list[str]:
+        if isinstance(payload, dict):
+            text = json.dumps(payload, ensure_ascii=True)
+        elif isinstance(payload, list):
+            text = json.dumps(payload, ensure_ascii=True)
+        else:
+            text = payload
+        matches = re.findall(r"collection://[0-9a-fA-F-]{8,}", text)
+        return NotionSprintManager._dedupe_keep_order(matches)
+
+    @staticmethod
+    def _dedupe_keep_order(values: Sequence[str]) -> list[str]:
+        deduped: list[str] = []
+        seen: set[str] = set()
+        for value in values:
+            normalized = value.strip()
+            if not normalized or normalized in seen:
+                continue
+            seen.add(normalized)
+            deduped.append(normalized)
+        return deduped
 
     @staticmethod
     def _extract_blocks(content: str) -> list[str]:

--- a/tests/unit/test_tasks_notion_sprint_tools.py
+++ b/tests/unit/test_tasks_notion_sprint_tools.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import json
+import asyncio
 
 import pytest
 
@@ -62,6 +63,81 @@ async def test_find_sprint_items_supports_query_and_filters():
     assert workbench.calls[0][1]["query"] == "sprint patch"
     assert workbench.calls[0][1]["data_source_url"] == "collection://sprint-db"
     assert workbench.calls[0][1]["filters"] == {"status": "WIP"}
+
+
+@pytest.mark.asyncio
+async def test_find_sprint_items_uses_default_data_source_when_missing():
+    workbench = _FakeWorkbench(
+        {"notion-search": [{"results": [{"id": "page-1", "title": "Open Ticket"}]}]}
+    )
+    manager = NotionSprintManager(
+        server_url="http://example.invalid/mcp",
+        workbench=workbench,
+        default_data_source_url="collection://f336d0bc-b841-465b-8045-024475c079dd",
+    )
+
+    result = await manager.find_sprint_items(
+        query="open tickets",
+        data_source_url=None,
+        filters=None,
+        limit=10,
+    )
+
+    assert result["ok"] is True
+    assert workbench.calls[0][0] == "notion-search"
+    assert (
+        workbench.calls[0][1]["data_source_url"]
+        == "collection://f336d0bc-b841-465b-8045-024475c079dd"
+    )
+
+
+@pytest.mark.asyncio
+async def test_find_sprint_items_resolves_data_source_from_default_database_id():
+    workbench = _FakeWorkbench(
+        {
+            "notion-fetch": [
+                '<database>\n<data-source url="collection://f336d0bc-b841-465b-8045-024475c079dd">\n'
+            ],
+            "notion-search": [{"results": [{"id": "page-1", "title": "Open Ticket"}]}],
+        }
+    )
+    manager = NotionSprintManager(
+        server_url="http://example.invalid/mcp",
+        workbench=workbench,
+        default_database_id="db-page-id",
+    )
+
+    result = await manager.find_sprint_items(
+        query="open tickets",
+        data_source_url=None,
+        filters=None,
+        limit=10,
+    )
+
+    assert result["ok"] is True
+    assert [name for name, _ in workbench.calls] == ["notion-fetch", "notion-search"]
+    assert (
+        workbench.calls[1][1]["data_source_url"]
+        == "collection://f336d0bc-b841-465b-8045-024475c079dd"
+    )
+
+
+@pytest.mark.asyncio
+async def test_find_sprint_items_returns_error_when_no_source_available():
+    manager = NotionSprintManager(
+        server_url="http://example.invalid/mcp",
+        workbench=_FakeWorkbench({}),
+    )
+
+    result = await manager.find_sprint_items(
+        query="open tickets",
+        data_source_url=None,
+        filters=None,
+        limit=10,
+    )
+
+    assert result["ok"] is False
+    assert "No Notion sprint data source is configured" in result["error"]
 
 
 @pytest.mark.asyncio
@@ -202,3 +278,315 @@ async def test_patch_sprint_page_accepts_langdiff_plan_json():
 
     assert result["ok"] is True
     assert result["verified"] is True
+
+
+@pytest.mark.asyncio
+async def test_patch_sprint_event_wraps_single_page_patch():
+    workbench = _FakeWorkbench(
+        {
+            "notion-fetch": [
+                "# Sprint Notes\n\nStatus: old phrase.\n",
+            ]
+        }
+    )
+    manager = NotionSprintManager(server_url="http://example.invalid/mcp", workbench=workbench)
+
+    result = await manager.patch_sprint_event(
+        page_id="page-1",
+        search_text="old phrase.",
+        replace_text="new phrase.",
+        langdiff_plan_json=None,
+        dry_run=True,
+        match_threshold=None,
+        match_distance=None,
+    )
+
+    assert result["ok"] is True
+    assert result["mode"] == "preview"
+    assert result["page_id"] == "page-1"
+    assert result["result"]["mode"] == "preview"
+    assert [name for name, _ in workbench.calls] == ["notion-fetch"]
+
+
+@pytest.mark.asyncio
+async def test_patch_sprint_events_searches_then_patches():
+    workbench = _FakeWorkbench(
+        {
+            "notion-search": [{"results": [{"id": "page-1"}, {"id": "page-2"}]}],
+            "notion-fetch": [
+                "# Sprint Notes\n\nStatus: old phrase.\n",
+                "# Sprint Notes\n\nStatus: old phrase.\n",
+            ],
+        }
+    )
+    manager = NotionSprintManager(server_url="http://example.invalid/mcp", workbench=workbench)
+
+    result = await manager.patch_sprint_events(
+        page_ids=None,
+        query="open sprint events",
+        data_source_url="collection://sprint-db",
+        filters={"status": "WIP"},
+        limit=2,
+        search_text="old phrase.",
+        replace_text="new phrase.",
+        langdiff_plan_json=None,
+        dry_run=True,
+        match_threshold=None,
+        match_distance=None,
+        stop_on_error=False,
+    )
+
+    assert result["ok"] is True
+    assert result["selection_mode"] == "search"
+    assert result["attempted"] == 2
+    assert result["patched"] == 2
+    assert result["failed"] == 0
+    assert [name for name, _ in workbench.calls] == [
+        "notion-search",
+        "notion-fetch",
+        "notion-fetch",
+    ]
+
+
+@pytest.mark.asyncio
+async def test_patch_sprint_events_requires_page_ids_or_query():
+    manager = NotionSprintManager(
+        server_url="http://example.invalid/mcp",
+        workbench=_FakeWorkbench({}),
+    )
+
+    result = await manager.patch_sprint_events(
+        page_ids=None,
+        query=None,
+        data_source_url=None,
+        filters=None,
+        limit=None,
+        search_text="old phrase.",
+        replace_text="new phrase.",
+        langdiff_plan_json=None,
+        dry_run=True,
+        match_threshold=None,
+        match_distance=None,
+        stop_on_error=None,
+    )
+
+    assert result["ok"] is False
+    assert result["selection_mode"] == "none"
+    assert result["attempted"] == 0
+
+
+@pytest.mark.asyncio
+async def test_patch_sprint_events_stops_on_first_error_by_default():
+    workbench = _FakeWorkbench(
+        {
+            "notion-search": [{"results": [{"id": "page-1"}, {"id": "page-2"}]}],
+            "notion-fetch": [
+                "# Sprint Notes\n\nStatus: unrelated text.\n",
+            ],
+        }
+    )
+    manager = NotionSprintManager(server_url="http://example.invalid/mcp", workbench=workbench)
+
+    result = await manager.patch_sprint_events(
+        page_ids=None,
+        query="open sprint events",
+        data_source_url="collection://sprint-db",
+        filters=None,
+        limit=2,
+        search_text="old phrase.",
+        replace_text="new phrase.",
+        langdiff_plan_json=None,
+        dry_run=True,
+        match_threshold=None,
+        match_distance=None,
+        stop_on_error=None,
+    )
+
+    assert result["ok"] is False
+    assert result["attempted"] == 1
+    assert result["failed"] == 1
+    assert [name for name, _ in workbench.calls] == ["notion-search", "notion-fetch"]
+
+
+@pytest.mark.asyncio
+async def test_find_sprint_items_queries_multiple_default_data_sources():
+    source_a = "collection://f336d0bc-b841-465b-8045-024475c079dd"
+    source_b = "collection://a5da15f6-b853-455d-8827-f906fb52db2b"
+    workbench = _FakeWorkbench(
+        {
+            "notion-search": [
+                {"results": [{"id": "page-1", "title": "Ticket A"}]},
+                {"results": [{"id": "page-2", "title": "Ticket B"}]},
+            ]
+        }
+    )
+    manager = NotionSprintManager(
+        server_url="http://example.invalid/mcp",
+        workbench=workbench,
+        default_data_source_urls=[source_a, source_b],
+    )
+
+    result = await manager.find_sprint_items(
+        query="open tickets",
+        data_source_url=None,
+        filters=None,
+        limit=10,
+    )
+
+    assert result["ok"] is True
+    assert result["count"] == 2
+    assert result["data_source_urls"] == [source_a, source_b]
+    search_calls = [args for name, args in workbench.calls if name == "notion-search"]
+    assert len(search_calls) == 2
+    assert search_calls[0]["data_source_url"] == source_a
+    assert search_calls[1]["data_source_url"] == source_b
+
+
+@pytest.mark.asyncio
+async def test_find_sprint_items_resolves_multiple_data_sources_from_multiple_databases():
+    source_a = "collection://f336d0bc-b841-465b-8045-024475c079dd"
+    source_b = "collection://a5da15f6-b853-455d-8827-f906fb52db2b"
+    workbench = _FakeWorkbench(
+        {
+            "notion-fetch": [
+                f'<database>\n<data-source url="{source_a}">\n',
+                f'<database>\n<data-source url="{source_b}">\n',
+            ],
+            "notion-search": [
+                {"results": [{"id": "page-1", "title": "Ticket A"}]},
+                {"results": [{"id": "page-2", "title": "Ticket B"}]},
+            ],
+        }
+    )
+    manager = NotionSprintManager(
+        server_url="http://example.invalid/mcp",
+        workbench=workbench,
+        default_database_ids=["db-a", "db-b"],
+    )
+
+    result = await manager.find_sprint_items(
+        query="open tickets",
+        data_source_url=None,
+        filters=None,
+        limit=10,
+    )
+
+    assert result["ok"] is True
+    assert result["count"] == 2
+    assert result["data_source_urls"] == [source_a, source_b]
+    assert [name for name, _ in workbench.calls] == [
+        "notion-fetch",
+        "notion-fetch",
+        "notion-search",
+        "notion-search",
+    ]
+
+
+@pytest.mark.asyncio
+async def test_find_sprint_items_continues_when_one_default_database_fetch_fails():
+    source_b = "collection://a5da15f6-b853-455d-8827-f906fb52db2b"
+    workbench = _FakeWorkbench(
+        {
+            "notion-fetch": [
+                RuntimeError("db-a unavailable"),
+                f'<database>\n<data-source url="{source_b}">\n',
+            ],
+            "notion-search": [{"results": [{"id": "page-2", "title": "Ticket B"}]}],
+        }
+    )
+    manager = NotionSprintManager(
+        server_url="http://example.invalid/mcp",
+        workbench=workbench,
+        default_database_ids=["db-a", "db-b"],
+    )
+
+    result = await manager.find_sprint_items(
+        query="open tickets",
+        data_source_url=None,
+        filters=None,
+        limit=10,
+    )
+
+    assert result["ok"] is True
+    assert result["count"] == 1
+    assert result["data_source_urls"] == [source_b]
+    fetch_calls = [name for name, _ in workbench.calls if name in {"notion-fetch", "notion_fetch"}]
+    assert len(fetch_calls) >= 2
+    assert workbench.calls[-1][0] == "notion-search"
+
+
+@pytest.mark.asyncio
+async def test_resolve_data_source_urls_parallelizes_default_database_fetches():
+    source_a = "collection://f336d0bc-b841-465b-8045-024475c079dd"
+    source_b = "collection://a5da15f6-b853-455d-8827-f906fb52db2b"
+    source_c = "collection://ef123456-7890-4abc-8123-1234567890ab"
+    payloads = {
+        "db-a": f'<database><data-source url="{source_a}"></database>',
+        "db-b": f'<database><data-source url="{source_b}"></database>',
+        "db-c": f'<database><data-source url="{source_c}"></database>',
+    }
+
+    manager = NotionSprintManager(
+        server_url="http://example.invalid/mcp",
+        workbench=_FakeWorkbench({}),
+        default_database_ids=["db-a", "db-b", "db-c"],
+    )
+
+    in_flight = 0
+    max_in_flight = 0
+
+    async def _call_tool_alias(_aliases, arguments):
+        nonlocal in_flight, max_in_flight
+        in_flight += 1
+        max_in_flight = max(max_in_flight, in_flight)
+        await asyncio.sleep(0.02)
+        in_flight -= 1
+        return payloads[arguments["id"]]
+
+    manager._call_tool_alias = _call_tool_alias  # type: ignore[method-assign]
+    resolved = await manager._resolve_data_source_urls(None)
+
+    assert resolved == [source_a, source_b, source_c]
+    assert max_in_flight >= 2
+
+
+@pytest.mark.asyncio
+async def test_patch_sprint_events_dry_run_supports_parallel_preview_with_ordering():
+    manager = NotionSprintManager(
+        server_url="http://example.invalid/mcp",
+        workbench=_FakeWorkbench({}),
+    )
+    manager._dry_run_patch_parallelism = 3  # type: ignore[attr-defined]
+    page_ids = ["page-1", "page-2", "page-3"]
+    delays = {"page-1": 0.03, "page-2": 0.01, "page-3": 0.02}
+
+    in_flight = 0
+    max_in_flight = 0
+
+    async def _patch(*, page_id, **_kwargs):
+        nonlocal in_flight, max_in_flight
+        in_flight += 1
+        max_in_flight = max(max_in_flight, in_flight)
+        await asyncio.sleep(delays[page_id])
+        in_flight -= 1
+        return {"ok": True, "mode": "preview", "summary": f"preview {page_id}"}
+
+    manager.patch_sprint_page_content = _patch  # type: ignore[method-assign]
+    result = await manager.patch_sprint_events(
+        page_ids=page_ids,
+        query=None,
+        data_source_url=None,
+        filters=None,
+        limit=None,
+        search_text="old phrase",
+        replace_text="new phrase",
+        langdiff_plan_json=None,
+        dry_run=True,
+        match_threshold=None,
+        match_distance=None,
+        stop_on_error=False,
+    )
+
+    assert result["ok"] is True
+    assert [row["page_id"] for row in result["results"]] == page_ids
+    assert max_in_flight >= 2

--- a/tests/unit/test_tasks_ticktick_list_tools.py
+++ b/tests/unit/test_tasks_ticktick_list_tools.py
@@ -1,3 +1,5 @@
+import asyncio
+
 import pytest
 
 from fateforger.agents.tasks.list_tools import TickTickListManager
@@ -176,6 +178,76 @@ async def test_show_list_items_returns_items():
 
 
 @pytest.mark.asyncio
+async def test_show_list_items_without_target_returns_all_projects_snapshot():
+    workbench = _FakeWorkbench(
+        {
+            "get_projects": [_project_listing(("Work", "PROJECT1"), ("Home", "PROJECT2"))],
+            "get_project_tasks": [
+                _task_listing("Work", ("T1", "Ship patch")),
+                _task_listing("Home", ("T2", "Buy groceries")),
+            ],
+        }
+    )
+    manager = TickTickListManager(server_url="http://example.invalid/mcp", workbench=workbench)
+
+    result = await manager.manage_ticktick_lists(
+        operation="show_list_items",
+        model="project",
+        list_name=None,
+        list_id=None,
+        items=None,
+        item_ids=None,
+        item_matches=None,
+        parent_task_id=None,
+        create_if_missing=True,
+    )
+
+    assert result["ok"] is True
+    assert result["data"]["list_name"] == "__all__"
+    assert len(result["data"]["items"]) == 2
+    assert "across all projects" in result["summary"]
+
+
+@pytest.mark.asyncio
+async def test_show_list_items_without_target_returns_all_items_across_projects():
+    workbench = _FakeWorkbench(
+        {
+            "get_projects": [_project_listing(("Work", "PROJECT1"), ("Home", "PROJECT2"))],
+            "get_project_tasks": [
+                _task_listing(
+                    "Work",
+                    ("T1", "Task 1"),
+                    ("T2", "Task 2"),
+                    ("T3", "Task 3"),
+                    ("T4", "Task 4"),
+                    ("T5", "Task 5"),
+                    ("T6", "Task 6"),
+                    ("T7", "Task 7"),
+                ),
+                _task_listing("Home", ("H1", "Home 1"), ("H2", "Home 2")),
+            ],
+        }
+    )
+    manager = TickTickListManager(server_url="http://example.invalid/mcp", workbench=workbench)
+
+    result = await manager.manage_ticktick_lists(
+        operation="show_list_items",
+        model="project",
+        list_name=None,
+        list_id=None,
+        items=None,
+        item_ids=None,
+        item_matches=None,
+        parent_task_id=None,
+        create_if_missing=True,
+    )
+
+    assert result["ok"] is True
+    assert result["data"]["list_name"] == "__all__"
+    assert len(result["data"]["items"]) == 9
+
+
+@pytest.mark.asyncio
 async def test_update_items_uses_item_ids():
     workbench = _FakeWorkbench(
         {
@@ -280,3 +352,183 @@ async def test_subtask_create_list_and_add_items():
         "create_subtask",
         "create_subtask",
     ]
+
+
+@pytest.mark.asyncio
+async def test_list_pending_tasks_returns_empty_when_mcp_is_unavailable():
+    manager = TickTickListManager(server_url="http://example.invalid/mcp", workbench=None)
+
+    async def _failing_list_projects():
+        raise RuntimeError("endpoint unavailable")
+
+    manager._list_projects = _failing_list_projects  # type: ignore[method-assign]
+    rows = await manager.list_pending_tasks(limit=5, per_project_limit=2)
+
+    assert rows == []
+
+
+@pytest.mark.asyncio
+async def test_list_pending_tasks_skips_project_failures_and_returns_remaining_rows():
+    manager = TickTickListManager(server_url="http://example.invalid/mcp", workbench=None)
+
+    async def _projects():
+        from fateforger.agents.tasks.list_tools import TickTickProject
+
+        return [
+            TickTickProject(id="P1", name="Work"),
+            TickTickProject(id="P2", name="Home"),
+        ]
+
+    async def _project_tasks(project_id: str):
+        from fateforger.agents.tasks.list_tools import TickTickTask
+
+        if project_id == "P1":
+            raise RuntimeError("project task endpoint failed")
+        return [TickTickTask(id="T2", title="Buy groceries", project_id="P2")]
+
+    manager._list_projects = _projects  # type: ignore[method-assign]
+    manager._list_project_tasks = _project_tasks  # type: ignore[method-assign]
+
+    rows = await manager.list_pending_tasks(limit=5, per_project_limit=2)
+
+    assert len(rows) == 1
+    assert rows[0].id == "T2"
+    assert rows[0].project_id == "P2"
+
+
+@pytest.mark.asyncio
+async def test_resolve_ticktick_task_mentions_returns_resolution_states():
+    workbench = _FakeWorkbench(
+        {
+            "get_projects": [_project_listing(("Work", "P1"), ("Home", "P2"))],
+            "get_project_tasks": [
+                _task_listing(
+                    "Work",
+                    ("T1", "Ship onboarding API"),
+                    ("T2", "Refactor auth middleware"),
+                ),
+                _task_listing(
+                    "Home",
+                    ("T3", "Buy milk"),
+                    ("T4", "Buy coffee beans"),
+                ),
+            ],
+        }
+    )
+    manager = TickTickListManager(server_url="http://example.invalid/mcp", workbench=workbench)
+
+    result = await manager.resolve_ticktick_task_mentions(
+        mentions=["Ship onboarding API", "Buy", "Plan vacation"],
+        expansion_queries=None,
+        max_candidates_per_mention=3,
+        min_score=0.45,
+        ambiguity_gap=0.08,
+        include_all_projects=True,
+    )
+
+    assert result["ok"] is True
+    assert result["status_counts"] == {"resolved": 1, "ambiguous": 1, "unresolved": 1}
+    statuses = {row["mention"]: row["status"] for row in result["results"]}
+    assert statuses["Ship onboarding API"] == "resolved"
+    assert statuses["Buy"] == "ambiguous"
+    assert statuses["Plan vacation"] == "unresolved"
+    assert [name for name, _ in workbench.calls] == [
+        "get_projects",
+        "get_project_tasks",
+        "get_project_tasks",
+    ]
+
+
+@pytest.mark.asyncio
+async def test_resolve_ticktick_task_mentions_uses_query_expansion():
+    workbench = _FakeWorkbench(
+        {
+            "get_projects": [_project_listing(("Finance", "P1"))],
+            "get_project_tasks": [
+                _task_listing(
+                    "Finance",
+                    ("T1", "File taxes 2026"),
+                    ("T2", "Renew insurance"),
+                )
+            ],
+        }
+    )
+    manager = TickTickListManager(server_url="http://example.invalid/mcp", workbench=workbench)
+
+    result = await manager.resolve_ticktick_task_mentions(
+        mentions=["tax filing"],
+        expansion_queries=["file taxes"],
+        max_candidates_per_mention=3,
+        min_score=0.45,
+        ambiguity_gap=0.08,
+        include_all_projects=True,
+    )
+
+    assert result["ok"] is True
+    row = result["results"][0]
+    assert row["status"] == "resolved"
+    assert row["resolved_task_id"] == "T1"
+    assert row["candidates"][0]["matched_query"] == "file taxes"
+
+
+@pytest.mark.asyncio
+async def test_list_pending_tasks_honors_bounded_parallelism_and_order():
+    manager = TickTickListManager(server_url="http://example.invalid/mcp", workbench=None)
+
+    async def _projects():
+        from fateforger.agents.tasks.list_tools import TickTickProject
+
+        return [
+            TickTickProject(id="P1", name="One"),
+            TickTickProject(id="P2", name="Two"),
+            TickTickProject(id="P3", name="Three"),
+            TickTickProject(id="P4", name="Four"),
+        ]
+
+    in_flight = 0
+    max_in_flight = 0
+
+    async def _project_tasks(project_id: str):
+        from fateforger.agents.tasks.list_tools import TickTickTask
+
+        nonlocal in_flight, max_in_flight
+        in_flight += 1
+        max_in_flight = max(max_in_flight, in_flight)
+        await asyncio.sleep(0.02)
+        in_flight -= 1
+        return [TickTickTask(id=f"T-{project_id}", title=f"Task {project_id}", project_id=project_id)]
+
+    manager._list_projects = _projects  # type: ignore[method-assign]
+    manager._list_project_tasks = _project_tasks  # type: ignore[method-assign]
+    manager._pending_snapshot_parallelism = 2  # type: ignore[attr-defined]
+
+    rows = await manager.list_pending_tasks(limit=4, per_project_limit=1)
+
+    assert [row.project_id for row in rows] == ["P1", "P2", "P3", "P4"]
+    assert max_in_flight <= 2
+
+
+@pytest.mark.asyncio
+async def test_invalid_input_preserves_parsed_operation_and_model_for_error_metadata():
+    workbench = _FakeWorkbench({})
+    manager = TickTickListManager(server_url="http://example.invalid/mcp", workbench=workbench)
+
+    result = await manager.manage_ticktick_lists(
+        operation="add_items",
+        model="subtask",
+        list_name=None,
+        list_id=None,
+        items=None,
+        item_ids=None,
+        item_matches=None,
+        parent_task_id=None,
+        create_if_missing=True,
+    )
+
+    assert result["ok"] is False
+    assert result["operation"] == "add_items"
+    assert result["model"] == "subtask"
+
+
+def test_extract_first_id_supports_hyphenated_and_underscored_ids():
+    assert TickTickListManager._extract_first_id("ID: abc-123_DEF") == "abc-123_DEF"


### PR DESCRIPTION
## Summary
Implements Issue #32 speed follow-ups for task-marshalling IO paths while preserving deterministic output semantics.

### Changes
- Bounded parallel TickTick project task fetch for pending snapshots (deterministic ordering preserved).
- Bounded parallel Notion default data-source resolution across configured DB IDs.
- Optional bounded parallel dry-run bulk sprint patch previews with deterministic output ordering.
- Added latency instrumentation events:
  - `ticktick_pending_snapshot_latency`
  - `notion_sprint_source_resolution_latency`
  - `notion_sprint_bulk_patch_latency`

## Validation
- Added test-first coverage for ordering/concurrency behavior.
- Ran:
  - `poetry run pytest -q tests/unit/test_tasks_ticktick_list_tools.py tests/unit/test_tasks_notion_sprint_tools.py tests/unit/test_tasks_agent_tool_wiring.py tests/unit/test_tasks_pending_snapshot.py tests/unit/test_timeboxing_task_marshalling_capability.py`
- Result: `47 passed`

## Live audit
- Real Slack thread/session run completed for session key `1772231863.654669`.
- Evidence log: `logs/timeboxing_session_20260227_223803_1772231863.654669_83279.log`.

Closes #32
