### PR TITLE
tasks/mcp: fail fast on invalid MCP URLs (no normalization/fallback)

### DIFF
--- a/src/fateforger/agents/tasks/notion_sprint_tools.py
+++ b/src/fateforger/agents/tasks/notion_sprint_tools.py
@@ -12,14 +12,12 @@ from hashlib import sha256
 from typing import Any, Sequence
 
 from pydantic import BaseModel, Field
-from yarl import URL
 
-from fateforger.tools.mcp_url_validation import rewrite_mcp_host
 from fateforger.tools.notion_mcp import (
     get_notion_mcp_headers,
     get_notion_mcp_url,
-    normalize_notion_mcp_url,
     probe_notion_mcp_endpoint,
+    validate_notion_mcp_url,
 )
 
 
@@ -66,7 +64,7 @@ class NotionSprintManager:
         default_source_resolution_parallelism: int = 4,
         dry_run_patch_parallelism: int = 4,
     ) -> None:
-        self._server_url = normalize_notion_mcp_url(
+        self._server_url = validate_notion_mcp_url(
             server_url or get_notion_mcp_url()
         ).strip()
         self._timeout = timeout
@@ -635,27 +633,7 @@ class NotionSprintManager:
             self._server_url, connect_timeout_s=min(self._timeout, 1.5)
         )
         if not ok:
-            parsed = URL(self._server_url)
-            if parsed.host == "notion-mcp":
-                fallback = rewrite_mcp_host(
-                    self._server_url, "localhost", default_path="/mcp"
-                )
-                fallback_ok, fallback_reason = probe_notion_mcp_endpoint(
-                    fallback, connect_timeout_s=min(self._timeout, 1.5)
-                )
-                if fallback_ok:
-                    logger.warning(
-                        "Notion MCP endpoint '%s' is unavailable (%s); using '%s'.",
-                        self._server_url,
-                        reason,
-                        fallback,
-                    )
-                    self._server_url = fallback
-                    ok = True
-                else:
-                    reason = fallback_reason or reason
-            if not ok:
-                raise RuntimeError(reason or "Notion MCP endpoint is unavailable.")
+            raise RuntimeError(reason or "Notion MCP endpoint is unavailable.")
         params = StreamableHttpServerParams(
             url=self._server_url,
             headers=get_notion_mcp_headers(),

--- a/tests/unit/test_mcp_url_validation.py
+++ b/tests/unit/test_mcp_url_validation.py
@@ -1,0 +1,68 @@
+from __future__ import annotations
+
+import pytest
+
+from fateforger.tools.notion_mcp import (
+    probe_notion_mcp_endpoint,
+    validate_notion_mcp_url,
+)
+from fateforger.tools.ticktick_mcp import (
+    probe_ticktick_mcp_endpoint,
+    validate_ticktick_mcp_url,
+)
+
+
+@pytest.mark.parametrize(
+    ("value", "expected_error"),
+    [
+        ("", "empty"),
+        ("ticktick-mcp:8000/mcp", "must include scheme"),
+        ("ftp://ticktick-mcp:8000/mcp", "must use http or https"),
+        ("http:///mcp", "must include a host"),
+        ("http://ticktick-mcp:8000/", "must include explicit path"),
+    ],
+)
+def test_validate_ticktick_mcp_url_fails_loudly(
+    value: str, expected_error: str
+) -> None:
+    with pytest.raises(ValueError, match=expected_error):
+        validate_ticktick_mcp_url(value)
+
+
+def test_validate_ticktick_mcp_url_does_not_normalize() -> None:
+    configured = "http://ticktick-mcp:8000/mcp?transport=sse"
+    assert validate_ticktick_mcp_url(configured) == configured
+
+
+def test_probe_ticktick_mcp_endpoint_reports_validation_error() -> None:
+    ok, reason = probe_ticktick_mcp_endpoint("ticktick-mcp:8000/mcp")
+    assert ok is False
+    assert "must include scheme" in reason
+
+
+@pytest.mark.parametrize(
+    ("value", "expected_error"),
+    [
+        ("", "empty"),
+        ("notion-mcp:3001/mcp", "must include scheme"),
+        ("ftp://notion-mcp:3001/mcp", "must use http or https"),
+        ("http:///mcp", "must include a host"),
+        ("http://notion-mcp:3001/", "must include explicit path"),
+    ],
+)
+def test_validate_notion_mcp_url_fails_loudly(
+    value: str, expected_error: str
+) -> None:
+    with pytest.raises(ValueError, match=expected_error):
+        validate_notion_mcp_url(value)
+
+
+def test_validate_notion_mcp_url_does_not_normalize() -> None:
+    configured = "http://notion-mcp:3001/mcp?transport=sse"
+    assert validate_notion_mcp_url(configured) == configured
+
+
+def test_probe_notion_mcp_endpoint_reports_validation_error() -> None:
+    ok, reason = probe_notion_mcp_endpoint("notion-mcp:3001/mcp")
+    assert ok is False
+    assert "must include scheme" in reason


### PR DESCRIPTION
## Summary
- Enforce strict TickTick/Notion MCP URL validation.
- Remove URL fallback/normalization behavior.
- Add regression tests for loud validation failures.

## Validation
- poetry run pytest -q tests/unit/test_mcp_url_validation.py tests/unit/test_tasks_ticktick_list_tools.py tests/unit/test_tasks_notion_sprint_tools.py
- poetry run pytest -q

## Notes
- Preserved prior WIP snapshot on branch: backup/preserve-wip-next-after-issue32-20260228-011019