### PR TITLE
timeboxing: honor typed stage reroutes for edit-anytime

### DIFF
--- a/src/fateforger/agents/timeboxing/stage_gating.py
+++ b/src/fateforger/agents/timeboxing/stage_gating.py
@@ -246,7 +246,8 @@ Decision rules
 - If the user supplies new details for the current stage, use action="provide_info".
 - If the user wants to move forward, use action="proceed".
 - If `stage_ready=true`, default to action="proceed" unless the user explicitly asks to stay/back/cancel or provides new scheduling facts.
-- If `current_stage=ReviewCommit` and the user provides corrections/changes/additions to the plan, use action="provide_info" (do not use proceed).
+- If the user asks for schedule/calendar edits at any stage, use action="provide_info" and set `target_stage` to `"Refine"` so the patch flow handles it.
+- If `current_stage=ReviewCommit` and the user provides corrections/changes/additions to the plan, use action="provide_info" with `target_stage="Refine"` (do not use proceed).
 - If the user pushes back on precision (for example "I don't need exact start times") and wants to keep moving, use action="proceed".
 - If the user asks to revisit earlier stages, use action="back" and set target_stage.
 - If the user asks to redo the current stage, use action="redo".


### PR DESCRIPTION
## Summary
- honor `StageDecision.target_stage` in GraphFlow `TransitionNode` for `action=provide_info`
- update decision prompt so schedule-edit intent routes to `target_stage=Refine` from any stage
- add regression tests for CollectConstraints/CaptureInputs -> Refine reroute

## Why
Issue #24 acceptance requires edit requests to route consistently through shared scheduling capability paths across stages. This change removes a transition gap where `provide_info` ignored typed target-stage reroutes.

## Validation
- `poetry run ruff check src/fateforger/agents/timeboxing/nodes/nodes.py src/fateforger/agents/timeboxing/stage_gating.py tests/unit/test_timeboxing_graphflow_state_machine.py`
- `poetry run pytest tests/unit/test_timeboxing_graphflow_state_machine.py -q`
- `poetry run pytest tests/unit/test_phase4_rewiring.py tests/unit/test_timeboxing_submit_flow.py -q`
- `poetry run pytest tests/unit -k timeboxing -q`

## Notes
- Live Slack audit captured stage reroute behavior and clear Stage 4 actionable response when no draft exists.
- Fresh-thread reply intermittency in local runtime remains a separate follow-up concern.

Closes #24
