### PR TITLE
issue-11: strict MCP endpoint validation + composable client refactor

### DIFF
--- a/src/fateforger/core/config.py
+++ b/src/fateforger/core/config.py
@@ -206,7 +206,7 @@ class Settings(BaseSettings):
     obs_llm_audit_mode: str = Field(default="sanitized")
     obs_llm_audit_max_chars: int = Field(default=2000)
 
-    @field_validator("slack_user_token")
+    @field_validator("slack_user_token", "slack_test_user_token")
     @classmethod
     def _validate_slack_user_token(cls, value: str) -> str:
         token = (value or "").strip()
@@ -214,7 +214,9 @@ class Settings(BaseSettings):
             return ""
         if token.startswith("xoxp-"):
             return token
-        raise ValueError("SLACK_USER_TOKEN must start with 'xoxp-' when provided")
+        raise ValueError(
+            "SLACK_USER_TOKEN and SLACK_TEST_USER_TOKEN must start with 'xoxp-' when provided"
+        )
 
     @field_validator("mcp_calendar_server_url", "mcp_calendar_server_url_docker")
     @classmethod
@@ -274,4 +276,3 @@ class Settings(BaseSettings):
 
 
 settings = Settings()
-# TODO: should automatically read the environment variables/.env

--- a/src/fateforger/tools/mcp_http_client.py
+++ b/src/fateforger/tools/mcp_http_client.py
@@ -1,0 +1,59 @@
+"""Shared composable streamable-HTTP MCP client primitives."""
+
+from __future__ import annotations
+
+from collections.abc import Mapping
+
+from fateforger.tools.mcp_url_validation import McpEndpointResolver
+
+
+class StreamableHttpMcpClient:
+    """Reusable MCP client with strict endpoint validation and reachability checks."""
+
+    def __init__(
+        self,
+        *,
+        resolver: McpEndpointResolver,
+        server_url: str,
+        timeout: float = 5.0,
+        connect_timeout_s: float = 1.5,
+        headers: Mapping[str, str] | None = None,
+    ) -> None:
+        from autogen_ext.tools.mcp import StreamableHttpServerParams
+
+        self._resolver = resolver
+        self._server_url = resolver.validate(server_url)
+        self._timeout = timeout
+        self._connect_timeout_s = connect_timeout_s
+        self._params = StreamableHttpServerParams(
+            url=self._server_url,
+            headers=dict(headers) if headers else None,
+            timeout=timeout,
+        )
+
+    def probe(self) -> tuple[bool, str | None]:
+        connect_timeout_s = min(self._timeout, self._connect_timeout_s)
+        return self._resolver.probe(
+            self._server_url, connect_timeout_s=connect_timeout_s
+        )
+
+    def _endpoint_name(self) -> str:
+        resolver = getattr(self, "_resolver", None)
+        policy = getattr(resolver, "policy", None)
+        name = getattr(policy, "name", None)
+        return name if isinstance(name, str) and name.strip() else "MCP"
+
+    async def get_tools(self) -> list:
+        """Load MCP tools from the configured endpoint."""
+        from autogen_ext.tools.mcp import mcp_server_tools
+
+        ok, reason = self.probe()
+        if not ok:
+            raise RuntimeError(reason or f"{self._endpoint_name()} endpoint is unavailable.")
+        tools = await mcp_server_tools(self._params)
+        if not tools:
+            raise RuntimeError(f"{self._endpoint_name()} server returned no tools")
+        return tools
+
+
+__all__ = ["StreamableHttpMcpClient"]

--- a/src/fateforger/tools/ticktick_mcp.py
+++ b/src/fateforger/tools/ticktick_mcp.py
@@ -5,6 +5,7 @@ TickTick Tools Configuration - MCP server parameters and tool loader.
 from __future__ import annotations
 
 import os
+from fateforger.tools.mcp_http_client import StreamableHttpMcpClient
 from fateforger.tools.mcp_url_validation import TickTickMcpEndpointResolver
 
 
@@ -13,10 +14,6 @@ _TICKTICK_ENDPOINT = TickTickMcpEndpointResolver()
 
 def get_ticktick_mcp_url() -> str:
     return _TICKTICK_ENDPOINT.resolve(os.environ)
-
-
-def normalize_ticktick_mcp_url(raw_url: str) -> str:
-    return _TICKTICK_ENDPOINT.validate(raw_url)
 
 
 def validate_ticktick_mcp_url(value: str) -> str:
@@ -35,35 +32,25 @@ def probe_ticktick_mcp_endpoint(
     return ok, reason or ""
 
 
-class TickTickMcpClient:
+class TickTickMcpClient(StreamableHttpMcpClient):
     def __init__(self, *, server_url: str, timeout: float = 5.0) -> None:
-        from autogen_ext.tools.mcp import StreamableHttpServerParams
-
-        self._server_url = validate_ticktick_mcp_url(server_url)
-        self._timeout = timeout
-        self._params = StreamableHttpServerParams(
-            url=self._server_url, timeout=timeout
+        super().__init__(
+            resolver=_TICKTICK_ENDPOINT,
+            server_url=server_url,
+            timeout=timeout,
+            connect_timeout_s=1.5,
         )
 
-    async def get_tools(self) -> list:
-        """Get TickTick MCP tools for use by LLM agents."""
-        from autogen_ext.tools.mcp import mcp_server_tools
-
+    def probe(self) -> tuple[bool, str]:
         ok, reason = probe_ticktick_mcp_endpoint(
             self._server_url, connect_timeout_s=min(self._timeout, 1.5)
         )
-        if not ok:
-            raise RuntimeError(reason or "TickTick MCP endpoint is unavailable.")
-        tools = await mcp_server_tools(self._params)
-        if not tools:
-            raise RuntimeError("TickTick MCP server returned no tools")
-        return tools
+        return ok, reason or ""
 
 
 __all__ = [
     "TickTickMcpClient",
     "get_ticktick_mcp_url",
-    "normalize_ticktick_mcp_url",
     "validate_ticktick_mcp_url",
     "probe_ticktick_mcp_endpoint",
 ]

--- a/tests/unit/test_mcp_url_validation.py
+++ b/tests/unit/test_mcp_url_validation.py
@@ -11,7 +11,6 @@ from fateforger.tools.mcp_url_validation import (
     TickTickMcpEndpointResolver,
 )
 from fateforger.tools.ticktick_mcp import (
-    normalize_ticktick_mcp_url,
     probe_ticktick_mcp_endpoint,
     validate_ticktick_mcp_url,
 )
@@ -37,11 +36,6 @@ def test_validate_ticktick_mcp_url_fails_loudly(
 def test_validate_ticktick_mcp_url_does_not_normalize() -> None:
     configured = "http://ticktick-mcp:8000/mcp?transport=sse"
     assert validate_ticktick_mcp_url(configured) == configured
-
-
-def test_normalize_ticktick_mcp_url_is_validate_only() -> None:
-    configured = "http://ticktick-mcp:8000/mcp?transport=sse"
-    assert normalize_ticktick_mcp_url(configured) == configured
 
 
 def test_probe_ticktick_mcp_endpoint_reports_validation_error() -> None:

--- a/tests/unit/test_notion_mcp_url.py
+++ b/tests/unit/test_notion_mcp_url.py
@@ -6,13 +6,13 @@ import fateforger.tools.notion_mcp as notion_mcp
 from fateforger.tools.notion_mcp import (
     NotionMcpClient,
     get_notion_mcp_url,
-    normalize_notion_mcp_url,
+    validate_notion_mcp_url,
 )
 
 
-def test_normalize_notion_mcp_url_validates_without_normalizing() -> None:
+def test_validate_notion_mcp_url_validates_without_normalizing() -> None:
     configured = "http://localhost:3001/mcp?transport=sse"
-    assert normalize_notion_mcp_url(configured) == configured
+    assert validate_notion_mcp_url(configured) == configured
 
 
 def test_get_notion_mcp_url_rejects_schemeless_env(monkeypatch) -> None:

--- a/tests/unit/test_settings_mcp_endpoints.py
+++ b/tests/unit/test_settings_mcp_endpoints.py
@@ -33,8 +33,20 @@ def test_settings_accepts_slack_user_token(monkeypatch) -> None:
     assert settings.slack_user_token == "xoxp-test-token"
 
 
+def test_settings_accepts_slack_test_user_token(monkeypatch) -> None:
+    monkeypatch.setenv("SLACK_TEST_USER_TOKEN", "xoxp-test-user-token")
+    settings = Settings()
+    assert settings.slack_test_user_token == "xoxp-test-user-token"
+
+
 def test_settings_rejects_invalid_slack_user_token(monkeypatch) -> None:
     monkeypatch.setenv("SLACK_USER_TOKEN", "invalid-token")
+    with pytest.raises(ValueError):
+        Settings()
+
+
+def test_settings_rejects_invalid_slack_test_user_token(monkeypatch) -> None:
+    monkeypatch.setenv("SLACK_TEST_USER_TOKEN", "invalid-token")
     with pytest.raises(ValueError):
         Settings()
 


### PR DESCRIPTION
## Summary
This PR implements the issue #11 slice to reduce fallback-heavy MCP endpoint/client handling and move validation to strict shared primitives.

## What changed
- Added shared composable MCP streamable-HTTP client base:
  - `src/fateforger/tools/mcp_http_client.py`
- Refactored Notion/TickTick MCP wrappers to use shared base:
  - `src/fateforger/tools/notion_mcp.py`
  - `src/fateforger/tools/ticktick_mcp.py`
- Pruned unused URL mutation helpers from endpoint validation module:
  - removed host/path rewrite helpers to enforce explicit valid config
  - `src/fateforger/tools/mcp_url_validation.py`
- Tightened root token validation:
  - `SLACK_USER_TOKEN` and `SLACK_TEST_USER_TOKEN` both require `xoxp-` when provided
  - `src/fateforger/core/config.py`
- Updated/expanded tests for validation and client behavior.

## Validation
- `poetry run pytest -q` (before): `773 passed, 10 skipped`
- `poetry run pytest -q tests/unit/test_mcp_url_validation.py tests/unit/test_notion_mcp_url.py tests/unit/test_ticktick_mcp_client.py tests/unit/test_settings_mcp_endpoints.py`: `37 passed`
- `poetry run pytest -q` (after): `774 passed, 10 skipped`

## Logging implementation compare/contrast (from #41)
Tracking issue: #41

### Option A: Metrics-only baseline
- Pros: fastest delivery, lowest operational overhead
- Cons: weak payload-level diagnosis for traceback/LLM-I/O incidents

### Option B: Metrics + structured LLM I/O logs (recommended baseline)
- Pros: best cost/debug value now; enables session/thread/stage/call_label correlation without full tracing stack
- Cons: cross-service causality still partly manual

### Option C: Full local triage stack (Prometheus + logs + traces)
- Pros: strongest anomaly -> trace -> payload debugging path
- Cons: highest complexity and maintenance

### Recommendation
- Land Option B first, then iterate toward Option C once baseline triage loops are stable.

## Open Items
- To decide: whether to set `Settings.model_config.extra` to `forbid` after env hygiene pass.
- To do: complete reviewer pass for strict validation behavior changes.
- Blocked by: none.
