### PR TITLE
WIP: #22 timeboxing patching/diffing hardening

### DIFF
--- a/src/fateforger/agents/timeboxing/submitter.py
+++ b/src/fateforger/agents/timeboxing/submitter.py
@@ -101,7 +101,7 @@ class CalendarSubmitter:
         )
 
         wb = self._get_workbench()
-        tx = await execute_sync(ops, wb)
+        tx = await execute_sync(ops, wb, halt_on_error=True)
         self._last_tx = tx
 
         logger.info("Sync transaction status: %s", tx.status)

--- a/tests/unit/test_calendar_submitter.py
+++ b/tests/unit/test_calendar_submitter.py
@@ -1,0 +1,63 @@
+"""Unit tests for CalendarSubmitter sync execution settings."""
+
+from __future__ import annotations
+
+from datetime import date, time, timedelta
+
+import pytest
+
+import fateforger.agents.timeboxing.submitter as submitter_module
+from fateforger.agents.timeboxing.sync_engine import SyncOp, SyncOpType, SyncTransaction
+from fateforger.agents.timeboxing.tb_models import ET, FixedStart, TBEvent, TBPlan
+
+
+def _plan() -> TBPlan:
+    return TBPlan(
+        events=[
+            TBEvent(
+                n="Deep work",
+                d="",
+                t=ET.DW,
+                p=FixedStart(st=time(9, 0), dur=timedelta(hours=1)),
+            )
+        ],
+        date=date(2025, 6, 15),
+        tz="Europe/Amsterdam",
+    )
+
+
+@pytest.mark.asyncio
+async def test_submit_plan_halts_on_first_sync_error(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Submitter should execute sync with halt_on_error enabled."""
+    captured: dict[str, bool] = {}
+
+    def _fake_plan_sync(*args, **kwargs):
+        _ = (args, kwargs)
+        return [
+            SyncOp(
+                op_type=SyncOpType.UPDATE,
+                gcal_event_id="fftb1",
+                after_payload={"calendarId": "primary", "eventId": "fftb1"},
+            )
+        ]
+
+    async def _fake_execute_sync(
+        ops, workbench, *, halt_on_error: bool = False
+    ) -> SyncTransaction:
+        _ = (ops, workbench)
+        captured["halt_on_error"] = halt_on_error
+        return SyncTransaction(status="committed")
+
+    monkeypatch.setattr(submitter_module, "plan_sync", _fake_plan_sync)
+    monkeypatch.setattr(submitter_module, "execute_sync", _fake_execute_sync)
+    submitter = submitter_module.CalendarSubmitter(server_url="http://localhost:3000")
+    monkeypatch.setattr(submitter, "_get_workbench", lambda: object())
+
+    tx = await submitter.submit_plan(
+        desired=_plan(),
+        remote=_plan(),
+        event_id_map={},
+    )
+
+    assert tx.status == "committed"
+    assert captured["halt_on_error"] is True


### PR DESCRIPTION
## Linked issue

- GitHub issue: #22
- Issue branch: `issue/22-timeboxing-patching-diffing-fixes`

## Acceptance criteria

- [x] Criterion 1: Non-retryable patch provider failures stop retry loop immediately (no attempt burn).
- [x] Criterion 2: Sync planning/execution emits explicit diff-path metadata for update operations.
- [x] Criterion 3: Submit path can halt on first sync failure to reduce cascading partial side effects.

## Notebook -> artifact mapping (required for notebook-driven work)

- Primary notebook path: none (`code-only-mode` for this slice)
- Notebook lifecycle status (`WIP` / `Extraction complete` / `DONE` / `Reference` / `Archived`): n/a
- Extracted implementation files (`src/...`):
  - `src/fateforger/agents/timeboxing/patching.py`
  - `src/fateforger/agents/timeboxing/sync_engine.py`
  - `src/fateforger/agents/timeboxing/submitter.py`
- Extracted test files (`tests/...`):
  - `tests/unit/test_patching.py`
  - `tests/unit/test_sync_engine.py`
  - `tests/unit/test_calendar_submitter.py`
- Extracted docs (`README.md` / `docs/...`): none in this slice
- Intentionally retained notebook-only content (and why): none

## Verification performed

- [x] Start-of-work cleanliness check recorded (`git status --porcelain`)
- [x] Pre-PR-close cleanliness check recorded (`git status --porcelain`)
- [x] Relevant automated tests passed
- [ ] Notebook checkpoint passed (clean-kernel rerun or CI notebook check) - not applicable (`code-only-mode`)

Commands run:

```bash
git rev-parse --abbrev-ref HEAD
git status --porcelain
poetry run pytest -q tests/unit/test_patching.py tests/unit/test_sync_engine.py tests/unit/test_calendar_submitter.py
git status --porcelain
```

## System-of-record sync

- [x] Issue status updated
- [x] PR description reflects current implementation status
- [x] Temporary `/tickets/` markdown removed or explicitly retained as durable documentation

## Scope and linked pain points

This PR consolidates patching/diffing improvements that directly reduce current timeboxing pain points and helps triage adjacent reliability/observability issues:

- #22 shared deterministic sync/undo hardening (partial incremental progress)
- #40 runtime reliability/no-reply diagnosis (clearer op-level failure behavior)
- #36 observability/root-cause pivotability (diff-path + execution metadata)

## Implementation summary

1. Patcher retry policy hardening
- Added retryability classification for patch/apply failures.
- Non-retryable provider failures (auth/permission/invalid-request style) now fail fast instead of consuming full retry budget.

2. Diff-aware sync execution telemetry
- Update ops now carry `diff_paths` derived from DeepDiff.
- Sync execution records include `op_type` and `diff_paths` for operation-level diagnostics.

3. Safer submit behavior
- `CalendarSubmitter.submit_plan()` now executes sync with `halt_on_error=True` to stop on first failed op.

## Open Items

### To decide
- Whether `halt_on_error=True` should become default across all sync callers or remain submitter-specific.

### To do
- Continue #22 broader shared-core refactor (calendar+notion adapters, deterministic undo store, concurrency policy).
- Add additional e2e Slack audit coverage for stage-4-to-submit progression under failure injection.

### Blocked by
- none
