### PR TITLE
Issue #44: guided task refinement session v0 + env-directed logging

### DIFF
--- a/.codex/skills/prometheus-agent-audit/SKILL.md
+++ b/.codex/skills/prometheus-agent-audit/SKILL.md
@@ -28,7 +28,11 @@ docker compose -f observability/docker-compose.yml up -d
 2. App metrics are enabled (default on):
 - `OBS_PROMETHEUS_ENABLED=1` (default)
 - `OBS_PROMETHEUS_PORT=9464` (default)
-3. Prometheus MCP active in VS Code (`.vscode/mcp.json` entry `prometheus` — uses `ghcr.io/pab1it0/prometheus-mcp-server:latest` via Docker stdio, `PROMETHEUS_URL=http://host.docker.internal:9090`).
+3. AutoGen event log direction is configured:
+- `AUTOGEN_EVENTS_LOG=summary|full|off`
+- `AUTOGEN_EVENTS_OUTPUT_TARGET=stdout|audit`
+- `AUTOGEN_EVENTS_FULL_PAYLOAD_MODE=sanitized|raw`
+4. Prometheus MCP active in VS Code (`.vscode/mcp.json` entry `prometheus` — uses `ghcr.io/pab1it0/prometheus-mcp-server:latest` via Docker stdio, `PROMETHEUS_URL=http://host.docker.internal:9090`).
 
 ## Query Guardrails
 - Default range window: last 15m to 60m.

--- a/.env.template
+++ b/.env.template
@@ -95,6 +95,16 @@ LOG_LEVEL=INFO
 DEVELOPMENT=true
 SCHEDULER_TIMEZONE=UTC
 
+# AutoGen event logging controls
+# summary|full|off
+AUTOGEN_EVENTS_LOG=summary
+# stdout|audit
+# - stdout: emit autogen_core.events lines to stdout (filtered by AUTOGEN_EVENTS_LOG)
+# - audit: suppress autogen_core.events stdout lines while still recording metrics + llm_io audit
+AUTOGEN_EVENTS_OUTPUT_TARGET=stdout
+# sanitized|raw (applies when AUTOGEN_EVENTS_LOG=full)
+AUTOGEN_EVENTS_FULL_PAYLOAD_MODE=sanitized
+
 # Development Settings
 PYTHONPATH=/app/src
 

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -191,6 +191,20 @@ Verify:
 2. Grafana: http://localhost:3000 (`admin` / `admin`)
 3. FateForger metrics endpoint: `http://localhost:9464/metrics` (when app runs with `OBS_PROMETHEUS_ENABLED=1`)
 
+Autogen event logging direction (set in `.env`):
+
+- `AUTOGEN_EVENTS_LOG=summary|full|off`
+- `AUTOGEN_EVENTS_OUTPUT_TARGET=stdout|audit`
+- `AUTOGEN_EVENTS_FULL_PAYLOAD_MODE=sanitized|raw` (used when `AUTOGEN_EVENTS_LOG=full`)
+
+Recommended secure default:
+
+```bash
+AUTOGEN_EVENTS_LOG=summary
+AUTOGEN_EVENTS_OUTPUT_TARGET=audit
+AUTOGEN_EVENTS_FULL_PAYLOAD_MODE=sanitized
+```
+
 Prometheus MCP server (Codex local config):
 
 - Server image: `ghcr.io/pab1it0/prometheus-mcp-server:latest`

--- a/src/fateforger/agents/tasks/AGENTS.md
+++ b/src/fateforger/agents/tasks/AGENTS.md
@@ -15,8 +15,19 @@
 - Do not perform destructive list/item operations when ambiguity exists.
 - For Notion sprint page edits, default to dry-run previews and fail safely on ambiguous/conflicting matches.
 - Keep assistant responses short and actionable; include operation outcome counts.
+- Guided refinement session v0 is a gated 4-phase flow (`scope` -> `scan` -> `refine` -> `close`).
+- Start commands are explicit (`/task-refine`, `start guided task refinement session`, `start task refinement session`, `start scrum refinement session`).
+- Cancel commands are explicit (`cancel|stop|exit task refinement session`).
+- During guided session turns, only advance phase when `gate_met=true`; otherwise remain in current phase and request missing fields.
+- On close gate success, persist a per-user recap in-memory and expose it via `GuidedRefinementRecapRequest`.
+- Keep guided flow focused on refinement quality (state, AC, DoD, sizing, dependencies, next action); do not turn it into scheduling.
 
 ## Testing
 
 - Add/update unit tests under `tests/unit/` for operation behavior and error paths.
 - Keep Slack routing behavior covered by existing handoff tests (unit/e2e).
+- Guided refinement changes must include tests for:
+  - start/cancel commands
+  - gate not met (phase held)
+  - gate met (phase advance)
+  - close recap persistence/retrieval

--- a/src/fateforger/agents/tasks/agent.py
+++ b/src/fateforger/agents/tasks/agent.py
@@ -3,11 +3,14 @@
 from __future__ import annotations
 
 import logging
+from dataclasses import dataclass, field
+from typing import Any
 
 from autogen_agentchat.agents import AssistantAgent
 from autogen_agentchat.messages import TextMessage
 from autogen_core import MessageContext, RoutedAgent, message_handler
 from autogen_core.tools import FunctionTool
+from pydantic import TypeAdapter
 
 from fateforger.core.config import settings
 from fateforger.debug.diag import with_timeout
@@ -15,13 +18,55 @@ from fateforger.llm import build_autogen_chat_client
 from fateforger.tools.ticktick_mcp import get_ticktick_mcp_url
 
 from .list_tools import TickTickListManager
-from .messages import PendingTaskItem, PendingTaskSnapshot, PendingTaskSnapshotRequest
+from .messages import (
+    GuidedRefinementPhase,
+    GuidedRefinementRecap,
+    GuidedRefinementRecapRequest,
+    GuidedRefinementRecapResponse,
+    GuidedRefinementTurn,
+    PendingTaskItem,
+    PendingTaskSnapshot,
+    PendingTaskSnapshotRequest,
+)
 from .notion_sprint_tools import NotionSprintManager
 
 logger = logging.getLogger(__name__)
 
-# TODO(refactor): centralize MCP client/tool loading + timeouts in shared helpers (see `fateforger.agents.timeboxing.mcp_clients`)
-# TODO(refactor): replace ad-hoc response handling with a shared `parse_chat_content` helper (see `fateforger.agents.timeboxing.pydantic_parsing`)
+_GUIDED_SESSION_START_COMMANDS = {
+    "start guided task refinement session",
+    "start task refinement session",
+    "start scrum refinement session",
+    "/task-refine",
+}
+_GUIDED_SESSION_CANCEL_COMMANDS = {
+    "cancel task refinement session",
+    "stop task refinement session",
+    "exit task refinement session",
+}
+_PHASE_ORDER = (
+    GuidedRefinementPhase.SCOPE,
+    GuidedRefinementPhase.SCAN,
+    GuidedRefinementPhase.REFINE,
+    GuidedRefinementPhase.CLOSE,
+)
+_PHASE_LABELS = {
+    GuidedRefinementPhase.SCOPE: "Scope",
+    GuidedRefinementPhase.SCAN: "Scan",
+    GuidedRefinementPhase.REFINE: "Refine",
+    GuidedRefinementPhase.CLOSE: "Close",
+}
+
+
+@dataclass
+class GuidedRefinementSessionState:
+    """In-memory v0 state for one guided refinement session."""
+
+    phase: GuidedRefinementPhase = GuidedRefinementPhase.SCOPE
+    phase_summaries: dict[GuidedRefinementPhase, list[str]] = field(
+        default_factory=dict
+    )
+    turns: int = 0
+    user_id: str = ""
 
 TASKS_PROMPT = """
 You are the FateForger Tasks Agent ("Task Marshal").
@@ -44,6 +89,37 @@ For Notion sprint operations:
 
 Be direct and concrete. If needed, ask 1-2 clarifying questions then propose a plan.
 Never invent IDs. If the tool reports ambiguity, ask a focused follow-up question.
+""".strip()
+
+GUIDED_REFINEMENT_PROMPT = """
+You run a quick, gated scrum-master refinement session (v0, 15 min style).
+
+Rules:
+- Keep responses concise and stepwise.
+- Do not auto-advance unless gate is met.
+- Ask for missing fields directly when gate is not met.
+- This flow is refinement, not scheduling.
+- Distinguish work state strictly:
+  - hypothesis (what must be true)
+  - research (what we need to learn)
+  - engineering (what to build/test)
+  - blocked (cannot progress now)
+
+Output contract:
+- Return only a GuidedRefinementTurn structured response.
+- Respect the current phase from the provided context.
+- `gate_met=true` only when phase requirements are satisfied.
+- On close phase, provide recap and set `session_complete=true`.
+
+Phase requirements:
+1) scope:
+   - selected project areas and board/list scope.
+2) scan:
+   - at least 3 active items reviewed (or explicit none).
+3) refine:
+   - refined items include state, acceptance criteria, binary DoD, size, dependencies, next action.
+4) close:
+   - concise recap with stuck/postponed signals and one intention line.
 """.strip()
 
 
@@ -101,12 +177,22 @@ class TasksAgent(RoutedAgent):
             reflect_on_tool_use=False,
             max_tool_iterations=2,
         )
+        self._guided_assistant = AssistantAgent(
+            name=f"{name}_guided_refinement_assistant",
+            system_message=GUIDED_REFINEMENT_PROMPT,
+            model_client=build_autogen_chat_client("tasks_agent"),
+            output_content_type=GuidedRefinementTurn,
+            reflect_on_tool_use=False,
+            max_tool_iterations=1,
+        )
+        self._guided_session: GuidedRefinementSessionState | None = None
+        self._latest_guided_recap_by_user: dict[str, GuidedRefinementRecap] = {}
 
+    @message_handler
     async def handle_pending_snapshot(
         self,
-        request: PendingTaskSnapshotRequest,
-        *,
-        ctx: object,
+        message: PendingTaskSnapshotRequest,
+        ctx: MessageContext,
     ) -> PendingTaskSnapshot:
         """Return a bounded snapshot of pending tasks for planning assistance.
 
@@ -114,8 +200,8 @@ class TasksAgent(RoutedAgent):
         the raw vendor objects to typed :class:`PendingTaskItem` records.
         """
         tasks = await self._list_manager.list_pending_tasks(
-            limit=request.limit,
-            per_project_limit=request.per_project_limit,
+            limit=message.limit,
+            per_project_limit=message.per_project_limit,
         )
         items = [
             PendingTaskItem(
@@ -132,19 +218,172 @@ class TasksAgent(RoutedAgent):
         )
 
     @message_handler
+    async def handle_guided_recap_request(
+        self, message: GuidedRefinementRecapRequest, ctx: MessageContext
+    ) -> GuidedRefinementRecapResponse:
+        _ = ctx
+        recap = self._latest_guided_recap_by_user.get(message.user_id)
+        if recap is None:
+            return GuidedRefinementRecapResponse(found=False, recap=None)
+        return GuidedRefinementRecapResponse(found=True, recap=recap)
+
+    @message_handler
     async def handle_text(
         self, message: TextMessage, ctx: MessageContext
     ) -> TextMessage:
+        content = (message.content or "").strip()
+        normalized = content.lower()
+        if normalized in _GUIDED_SESSION_CANCEL_COMMANDS and self._guided_session:
+            self._guided_session = None
+            return TextMessage(
+                content="Guided task refinement session canceled.",
+                source="tasks_agent",
+            )
+
+        if normalized in _GUIDED_SESSION_START_COMMANDS:
+            self._guided_session = GuidedRefinementSessionState(user_id=message.source)
+            return self._render_phase_intro(self._guided_session)
+
+        if self._guided_session is not None:
+            return await self._handle_guided_session_turn(message=message, ctx=ctx)
+
         response = await with_timeout(
             "tasks:on_messages",
             self._assistant.on_messages([message], ctx.cancellation_token),
-            timeout_s=20,
+            timeout_s=float(getattr(settings, "agent_on_messages_timeout_seconds", 20)),
         )
         chat_message = getattr(response, "chat_message", None)
         if isinstance(chat_message, TextMessage):
             return chat_message
-        content = getattr(chat_message, "content", None) if chat_message else None
-        return TextMessage(content=str(content or "(no response)"), source=self.id.type)
+        fallback = getattr(chat_message, "content", None) if chat_message else None
+        return TextMessage(
+            content=str(fallback or "(no response)"),
+            source="tasks_agent",
+        )
+
+    async def _handle_guided_session_turn(
+        self, *, message: TextMessage, ctx: MessageContext
+    ) -> TextMessage:
+        assert self._guided_session is not None
+        session = self._guided_session
+        phase = session.phase
+        context = self._build_guided_context(session=session, user_message=message.content)
+        try:
+            response = await with_timeout(
+                "tasks:guided_refinement",
+                self._guided_assistant.on_messages(
+                    [TextMessage(content=context, source=message.source)],
+                    ctx.cancellation_token,
+                ),
+                timeout_s=float(getattr(settings, "agent_on_messages_timeout_seconds", 20)),
+            )
+            turn = self._extract_guided_turn(response)
+        except Exception as exc:
+            logger.exception("Guided task refinement turn failed")
+            return TextMessage(
+                content=(
+                    f"*Guided Refinement — Phase {self._phase_position(phase)}/{len(_PHASE_ORDER)} "
+                    f"({self._phase_label(phase)})*\n"
+                    "Gate: ❌ not met\n"
+                    f"Error: {type(exc).__name__}. Please rephrase briefly and try again."
+                ),
+                source="tasks_agent",
+            )
+
+        session.turns += 1
+        if turn.phase_summary:
+            existing = list(session.phase_summaries.get(phase, []))
+            existing.extend(turn.phase_summary)
+            session.phase_summaries[phase] = existing[-8:]
+
+        if turn.gate_met:
+            if phase == GuidedRefinementPhase.CLOSE or turn.session_complete:
+                if turn.recap is not None and session.user_id:
+                    self._latest_guided_recap_by_user[session.user_id] = turn.recap
+                self._guided_session = None
+            else:
+                session.phase = self._next_phase(phase)
+
+        return self._render_guided_turn(phase=phase, turn=turn)
+
+    def _build_guided_context(
+        self, *, session: GuidedRefinementSessionState, user_message: str
+    ) -> str:
+        prior = []
+        for phase in _PHASE_ORDER:
+            lines = session.phase_summaries.get(phase, [])
+            if not lines:
+                continue
+            prior.append(f"{self._phase_label(phase)}: " + " | ".join(lines[-3:]))
+        prior_text = "\n".join(f"- {line}" for line in prior) if prior else "- none yet"
+        return (
+            "Guided task refinement context\n"
+            f"Current phase: {session.phase.value}\n"
+            f"Session turns so far: {session.turns}\n"
+            "Prior phase summaries:\n"
+            f"{prior_text}\n\n"
+            f"User message:\n{user_message}\n"
+        )
+
+    @staticmethod
+    def _extract_guided_turn(response: Any) -> GuidedRefinementTurn:
+        content = getattr(getattr(response, "chat_message", None), "content", None)
+        if isinstance(content, GuidedRefinementTurn):
+            return content
+        return TypeAdapter(GuidedRefinementTurn).validate_python(content)
+
+    @staticmethod
+    def _phase_label(phase: GuidedRefinementPhase) -> str:
+        return _PHASE_LABELS.get(phase, phase.value.title())
+
+    @staticmethod
+    def _phase_position(phase: GuidedRefinementPhase) -> int:
+        return _PHASE_ORDER.index(phase) + 1
+
+    @staticmethod
+    def _next_phase(phase: GuidedRefinementPhase) -> GuidedRefinementPhase:
+        idx = _PHASE_ORDER.index(phase)
+        if idx + 1 >= len(_PHASE_ORDER):
+            return GuidedRefinementPhase.CLOSE
+        return _PHASE_ORDER[idx + 1]
+
+    def _render_phase_intro(self, session: GuidedRefinementSessionState) -> TextMessage:
+        phase = session.phase
+        intro = (
+            f"*Guided Refinement — Phase {self._phase_position(phase)}/{len(_PHASE_ORDER)} "
+            f"({self._phase_label(phase)})*\n"
+            "Gate: ⏳ pending\n"
+            "Quick start: name the boards/lists and 2-3 project areas to refine "
+            "(include work + personal if relevant)."
+        )
+        return TextMessage(content=intro, source="tasks_agent")
+
+    def _render_guided_turn(
+        self, *, phase: GuidedRefinementPhase, turn: GuidedRefinementTurn
+    ) -> TextMessage:
+        gate_line = "✅ met" if turn.gate_met else "❌ not met"
+        lines = [
+            f"*Guided Refinement — Phase {self._phase_position(phase)}/{len(_PHASE_ORDER)} ({self._phase_label(phase)})*",
+            f"Gate: {gate_line}",
+            turn.assistant_message.strip(),
+        ]
+        if turn.phase_summary:
+            lines.append("*Captured so far:*")
+            lines.extend(f"- {item}" for item in turn.phase_summary[:5])
+        if turn.missing_fields and not turn.gate_met:
+            lines.append("*Still needed:*")
+            lines.extend(f"- {item}" for item in turn.missing_fields[:5])
+        if turn.recap:
+            lines.append("*Session recap:*")
+            lines.append(f"- {turn.recap.summary or 'No summary provided.'}")
+            if turn.recap.user_intention:
+                lines.append(f"- Intention: {turn.recap.user_intention}")
+            if turn.recap.stuck_or_postponed_signals:
+                lines.extend(
+                    f"- Stuck signal: {item}"
+                    for item in turn.recap.stuck_or_postponed_signals[:3]
+                )
+        return TextMessage(content="\n".join(lines), source="tasks_agent")
 
 
 __all__ = ["TasksAgent"]

--- a/src/fateforger/agents/tasks/messages.py
+++ b/src/fateforger/agents/tasks/messages.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+from enum import Enum
+
 from pydantic import BaseModel, Field
 
 
@@ -30,8 +32,73 @@ class PendingTaskSnapshot(BaseModel):
     summary: str = ""
 
 
+class GuidedRefinementPhase(str, Enum):
+    """Phase IDs for guided task refinement sessions."""
+
+    SCOPE = "scope"
+    SCAN = "scan"
+    REFINE = "refine"
+    CLOSE = "close"
+
+
+class GuidedRefinedWorkItem(BaseModel):
+    """Refined work item shape emitted by the guided session."""
+
+    title: str
+    project_area: str
+    state: str = Field(
+        description="One of: hypothesis, research, engineering, blocked."
+    )
+    acceptance_criteria: list[str] = Field(default_factory=list)
+    definition_of_done_binary: str
+    size: str = Field(description="Expected size bucket, e.g. XS/S/M/L.")
+    blocked_by: list[str] = Field(default_factory=list)
+    next_action: str
+
+
+class GuidedRefinementRecap(BaseModel):
+    """Structured recap for cross-agent consumption."""
+
+    focus_areas: list[str] = Field(default_factory=list)
+    refined_items: list[GuidedRefinedWorkItem] = Field(default_factory=list)
+    stuck_or_postponed_signals: list[str] = Field(default_factory=list)
+    user_intention: str = ""
+    summary: str = ""
+
+
+class GuidedRefinementTurn(BaseModel):
+    """Structured assistant output for one guided session turn."""
+
+    phase: GuidedRefinementPhase
+    gate_met: bool = False
+    missing_fields: list[str] = Field(default_factory=list)
+    phase_summary: list[str] = Field(default_factory=list)
+    assistant_message: str
+    recap: GuidedRefinementRecap | None = None
+    session_complete: bool = False
+
+
+class GuidedRefinementRecapRequest(BaseModel):
+    """Request the most recent guided-refinement recap for a user."""
+
+    user_id: str
+
+
+class GuidedRefinementRecapResponse(BaseModel):
+    """Response carrying the latest guided-refinement recap, if any."""
+
+    found: bool = False
+    recap: GuidedRefinementRecap | None = None
+
+
 __all__ = [
     "PendingTaskSnapshotRequest",
     "PendingTaskItem",
     "PendingTaskSnapshot",
+    "GuidedRefinementPhase",
+    "GuidedRefinedWorkItem",
+    "GuidedRefinementRecap",
+    "GuidedRefinementTurn",
+    "GuidedRefinementRecapRequest",
+    "GuidedRefinementRecapResponse",
 ]

--- a/src/fateforger/core/config.py
+++ b/src/fateforger/core/config.py
@@ -205,6 +205,9 @@ class Settings(BaseSettings):
     obs_llm_audit_enabled: bool = Field(default=True)
     obs_llm_audit_mode: str = Field(default="sanitized")
     obs_llm_audit_max_chars: int = Field(default=2000)
+    autogen_events_log: str = Field(default="summary")
+    autogen_events_output_target: str = Field(default="stdout")
+    autogen_events_full_payload_mode: str = Field(default="sanitized")
 
     @field_validator("slack_user_token", "slack_test_user_token")
     @classmethod
@@ -257,6 +260,43 @@ class Settings(BaseSettings):
             return backend
         raise ValueError(
             "TIMEBOXING_MEMORY_BACKEND must be one of: constraint_mcp, mem0"
+        )
+
+    @field_validator("autogen_events_log")
+    @classmethod
+    def _validate_autogen_events_log(cls, value: str) -> str:
+        mode = (value or "").strip().lower()
+        alias = {
+            "0": "off",
+            "false": "off",
+            "none": "off",
+            "1": "full",
+            "true": "full",
+            "on": "full",
+        }
+        normalized = alias.get(mode, mode)
+        if normalized in {"summary", "full", "off"}:
+            return normalized
+        raise ValueError("AUTOGEN_EVENTS_LOG must be one of: summary, full, off")
+
+    @field_validator("autogen_events_output_target")
+    @classmethod
+    def _validate_autogen_events_output_target(cls, value: str) -> str:
+        target = (value or "").strip().lower()
+        if target in {"stdout", "audit"}:
+            return target
+        raise ValueError(
+            "AUTOGEN_EVENTS_OUTPUT_TARGET must be one of: stdout, audit"
+        )
+
+    @field_validator("autogen_events_full_payload_mode")
+    @classmethod
+    def _validate_autogen_events_full_payload_mode(cls, value: str) -> str:
+        mode = (value or "").strip().lower()
+        if mode in {"sanitized", "raw"}:
+            return mode
+        raise ValueError(
+            "AUTOGEN_EVENTS_FULL_PAYLOAD_MODE must be one of: sanitized, raw"
         )
 
     @model_validator(mode="after")

--- a/src/fateforger/slack_bot/AGENTS.md
+++ b/src/fateforger/slack_bot/AGENTS.md
@@ -15,6 +15,8 @@
 - **Never** add regex/keyword-based intent routing in `handlers.py`. Use LLM classification or explicit slash commands.
 - Thread focus (`focus.py`) is the mechanism for routing follow-up messages to the owning agent without re-triage.
 - Suppress planning nudges while a timeboxing session is active (handled by `PlanningReconciler`).
+- Tasks guided refinement entrypoint is `/task-refine`; the command should dispatch a deterministic session start message to `tasks_agent`.
+- After `/task-refine`, follow-up thread messages must continue on `tasks_agent` via focus routing instead of re-triage.
 
 ## Action Handlers
 

--- a/tests/unit/test_settings_mcp_endpoints.py
+++ b/tests/unit/test_settings_mcp_endpoints.py
@@ -96,3 +96,31 @@ def test_settings_rejects_invalid_ticktick_mcp_url(monkeypatch) -> None:
     monkeypatch.setenv("TICKTICK_MCP_URL", "ticktick-mcp:8000/mcp")
     with pytest.raises(ValueError):
         Settings()
+
+
+def test_settings_accepts_autogen_event_logging_directives(monkeypatch) -> None:
+    monkeypatch.setenv("AUTOGEN_EVENTS_LOG", "summary")
+    monkeypatch.setenv("AUTOGEN_EVENTS_OUTPUT_TARGET", "audit")
+    monkeypatch.setenv("AUTOGEN_EVENTS_FULL_PAYLOAD_MODE", "sanitized")
+    settings = Settings()
+    assert settings.autogen_events_log == "summary"
+    assert settings.autogen_events_output_target == "audit"
+    assert settings.autogen_events_full_payload_mode == "sanitized"
+
+
+def test_settings_rejects_invalid_autogen_events_log(monkeypatch) -> None:
+    monkeypatch.setenv("AUTOGEN_EVENTS_LOG", "verbose")
+    with pytest.raises(ValueError):
+        Settings()
+
+
+def test_settings_rejects_invalid_autogen_events_output_target(monkeypatch) -> None:
+    monkeypatch.setenv("AUTOGEN_EVENTS_OUTPUT_TARGET", "file")
+    with pytest.raises(ValueError):
+        Settings()
+
+
+def test_settings_rejects_invalid_autogen_events_full_payload_mode(monkeypatch) -> None:
+    monkeypatch.setenv("AUTOGEN_EVENTS_FULL_PAYLOAD_MODE", "safe")
+    with pytest.raises(ValueError):
+        Settings()

--- a/tests/unit/test_tasks_guided_refinement_session.py
+++ b/tests/unit/test_tasks_guided_refinement_session.py
@@ -1,0 +1,183 @@
+from __future__ import annotations
+
+import types
+
+import pytest
+
+pytest.importorskip("autogen_core")
+pytest.importorskip("autogen_agentchat.agents")
+
+from autogen_agentchat.messages import TextMessage
+from autogen_core import CancellationToken, DefaultTopicId, MessageContext
+
+from fateforger.agents.tasks import agent as tasks_agent_module
+from fateforger.agents.tasks.messages import (
+    GuidedRefinementPhase,
+    GuidedRefinementRecap,
+    GuidedRefinementRecapRequest,
+    GuidedRefinementTurn,
+)
+
+
+def _ctx() -> MessageContext:
+    return MessageContext(
+        sender=None,
+        topic_id=DefaultTopicId(),
+        is_rpc=False,
+        cancellation_token=CancellationToken(),
+        message_id="m1",
+    )
+
+
+def _build_agent(monkeypatch: pytest.MonkeyPatch) -> tasks_agent_module.TasksAgent:
+    class DummyAssistantAgent:
+        def __init__(self, **_kwargs):
+            return None
+
+    monkeypatch.setattr(tasks_agent_module, "AssistantAgent", DummyAssistantAgent)
+    monkeypatch.setattr(tasks_agent_module, "build_autogen_chat_client", lambda _name: object())
+    return tasks_agent_module.TasksAgent("tasks_agent")
+
+
+@pytest.mark.asyncio
+async def test_start_guided_refinement_session_sets_phase_scope(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    agent = _build_agent(monkeypatch)
+
+    result = await agent.handle_text(
+        TextMessage(content="start guided task refinement session", source="U1"),
+        _ctx(),
+    )
+
+    assert "Guided Refinement — Phase 1/4 (Scope)" in result.content
+    assert "Gate: ⏳ pending" in result.content
+    assert agent._guided_session is not None
+    assert agent._guided_session.phase == GuidedRefinementPhase.SCOPE
+
+
+@pytest.mark.asyncio
+async def test_guided_session_gate_not_met_stays_in_same_phase(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    agent = _build_agent(monkeypatch)
+    await agent.handle_text(
+        TextMessage(content="start guided task refinement session", source="U1"),
+        _ctx(),
+    )
+
+    class _FakeGuidedAssistant:
+        async def on_messages(self, _messages, _cancellation_token):
+            return types.SimpleNamespace(
+                chat_message=types.SimpleNamespace(
+                    content=GuidedRefinementTurn(
+                        phase=GuidedRefinementPhase.SCOPE,
+                        gate_met=False,
+                        missing_fields=["project areas"],
+                        phase_summary=["Work board selected"],
+                        assistant_message="Need project areas and personal scope.",
+                    )
+                )
+            )
+
+    async def _timeout_passthrough(_label, awaitable, *, timeout_s):
+        _ = timeout_s
+        return await awaitable
+
+    monkeypatch.setattr(tasks_agent_module, "with_timeout", _timeout_passthrough)
+    agent._guided_assistant = _FakeGuidedAssistant()
+
+    result = await agent.handle_text(
+        TextMessage(content="Work board only", source="U1"), _ctx()
+    )
+
+    assert "Gate: ❌ not met" in result.content
+    assert "Still needed" in result.content
+    assert agent._guided_session is not None
+    assert agent._guided_session.phase == GuidedRefinementPhase.SCOPE
+
+
+@pytest.mark.asyncio
+async def test_guided_session_gate_met_advances_phase(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    agent = _build_agent(monkeypatch)
+    await agent.handle_text(
+        TextMessage(content="start guided task refinement session", source="U1"),
+        _ctx(),
+    )
+
+    class _FakeGuidedAssistant:
+        async def on_messages(self, _messages, _cancellation_token):
+            return types.SimpleNamespace(
+                chat_message=types.SimpleNamespace(
+                    content=GuidedRefinementTurn(
+                        phase=GuidedRefinementPhase.SCOPE,
+                        gate_met=True,
+                        phase_summary=["Work + personal scope selected"],
+                        assistant_message="Scope captured. Proceeding.",
+                    )
+                )
+            )
+
+    async def _timeout_passthrough(_label, awaitable, *, timeout_s):
+        _ = timeout_s
+        return await awaitable
+
+    monkeypatch.setattr(tasks_agent_module, "with_timeout", _timeout_passthrough)
+    agent._guided_assistant = _FakeGuidedAssistant()
+
+    await agent.handle_text(TextMessage(content="scope details", source="U1"), _ctx())
+
+    assert agent._guided_session is not None
+    assert agent._guided_session.phase == GuidedRefinementPhase.SCAN
+
+
+@pytest.mark.asyncio
+async def test_guided_session_close_persists_recap(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    agent = _build_agent(monkeypatch)
+    agent._guided_session = tasks_agent_module.GuidedRefinementSessionState(
+        phase=GuidedRefinementPhase.CLOSE,
+        user_id="U1",
+    )
+
+    recap = GuidedRefinementRecap(
+        summary="Refined four items across work + personal.",
+        user_intention="Execute top two next actions tomorrow.",
+        stuck_or_postponed_signals=["Ticket A postponed 3 times"],
+    )
+
+    class _FakeGuidedAssistant:
+        async def on_messages(self, _messages, _cancellation_token):
+            return types.SimpleNamespace(
+                chat_message=types.SimpleNamespace(
+                    content=GuidedRefinementTurn(
+                        phase=GuidedRefinementPhase.CLOSE,
+                        gate_met=True,
+                        assistant_message="Session complete.",
+                        recap=recap,
+                        session_complete=True,
+                    )
+                )
+            )
+
+    async def _timeout_passthrough(_label, awaitable, *, timeout_s):
+        _ = timeout_s
+        return await awaitable
+
+    monkeypatch.setattr(tasks_agent_module, "with_timeout", _timeout_passthrough)
+    agent._guided_assistant = _FakeGuidedAssistant()
+
+    result = await agent.handle_text(TextMessage(content="close", source="U1"), _ctx())
+    assert "Session recap" in result.content
+    assert agent._guided_session is None
+
+    recap_response = await agent.handle_guided_recap_request(
+        GuidedRefinementRecapRequest(user_id="U1"),
+        _ctx(),
+    )
+    assert recap_response.found is True
+    assert recap_response.recap is not None
+    assert recap_response.recap.summary == recap.summary


### PR DESCRIPTION
## Linked issue
- #44

## Summary
- Adds guided 4-phase task refinement session (`scope -> scan -> refine -> close`) in `TasksAgent`.
- Adds `/task-refine` Slack command routing into `tasks_agent` session start.
- Adds structured recap contract + recap retrieval message contract.
- Adds env-directed AutoGen event logging controls with strict root validation:
  - `AUTOGEN_EVENTS_LOG=summary|full|off`
  - `AUTOGEN_EVENTS_OUTPUT_TARGET=stdout|audit`
  - `AUTOGEN_EVENTS_FULL_PAYLOAD_MODE=sanitized|raw`
- Updates AGENTS/docs/skill runbook for audit flow.

## Validation
```bash
poetry run pytest -q tests/unit/test_settings_mcp_endpoints.py tests/unit/test_logging_config_filters.py tests/unit/test_observability_metrics.py tests/unit/test_timebox_log_query_llm.py tests/unit/test_tasks_guided_refinement_session.py tests/unit/test_tasks_agent_tool_wiring.py tests/unit/test_tasks_pending_snapshot.py tests/unit/test_slack_timeboxing_routing.py tests/unit/test_receptionist_handoff_message.py
```
Result: `46 passed`

## Open Items
- To decide: default `AUTOGEN_EVENTS_OUTPUT_TARGET` policy for shared dev environments (`stdout` vs `audit`).
- To do: run live Slack `/task-refine` end-to-end audit and attach correlated Prometheus + llm_io evidence.
- Blocked by: none.
