### PR TITLE
Task defaults durability: explicit backend + deterministic fallback logging

### DIFF
--- a/.env.template
+++ b/.env.template
@@ -95,6 +95,21 @@ LOG_LEVEL=INFO
 DEVELOPMENT=true
 SCHEDULER_TIMEZONE=UTC
 
+# Durable memory backend selection
+# - TIMEBOXING_MEMORY_BACKEND: constraint_mcp|mem0
+# - TASKS_DEFAULTS_MEMORY_BACKEND: constraint_mcp|mem0|disabled|inherit_timeboxing
+TIMEBOXING_MEMORY_BACKEND=constraint_mcp
+TASKS_DEFAULTS_MEMORY_BACKEND=constraint_mcp
+# Optional fallback cache path when durable task defaults backend is unavailable.
+TASKS_DEFAULTS_CACHE_PATH=logs/taskmarshal_defaults_cache.json
+
+# Mem0 backend settings (required only when a selected backend is mem0)
+MEM0_USER_ID=timeboxing
+MEM0_IS_CLOUD=false
+MEM0_API_KEY=
+MEM0_LOCAL_CONFIG_JSON=
+MEM0_QUERY_LIMIT=200
+
 # AutoGen event logging controls
 # summary|full|off
 AUTOGEN_EVENTS_LOG=summary

--- a/src/fateforger/agents/tasks/README.md
+++ b/src/fateforger/agents/tasks/README.md
@@ -25,6 +25,11 @@ Notes:
 - Uses TickTick MCP via `manage_ticktick_lists` when `TICKTICK_MCP_URL` is configured.
 - Pending-task snapshots fail closed (empty result) when TickTick MCP is unreachable, so timeboxing can continue without noisy hard failures.
 - Uses Notion MCP for sprint-domain operations via the task tools above.
+- Due-task defaults backend is explicitly controlled by `TASKS_DEFAULTS_MEMORY_BACKEND`:
+  `constraint_mcp` (default), `mem0`, `disabled`, or `inherit_timeboxing`.
+- If the configured durable backend cannot initialize, TaskMarshal falls back to
+  local disk cache (`TASKS_DEFAULTS_CACHE_PATH`) and logs a structured one-time
+  warning per user/reason (`mode=fallback_cache`, `reason_code=...`).
 - Notion sprint discovery supports single-source and multi-source defaults via:
   `NOTION_SPRINT_DATA_SOURCE_URL` / `NOTION_SPRINT_DB_ID` and
   `NOTION_SPRINT_DATA_SOURCE_URLS` / `NOTION_SPRINT_DB_IDS`.

--- a/src/fateforger/agents/tasks/__init__.py
+++ b/src/fateforger/agents/tasks/__init__.py
@@ -1,6 +1,15 @@
 """Tasks agent package."""
 
-from .agent import TasksAgent
+from __future__ import annotations
+
+from typing import Any
 
 __all__ = ["TasksAgent"]
 
+
+def __getattr__(name: str) -> Any:
+    if name == "TasksAgent":
+        from .agent import TasksAgent
+
+        return TasksAgent
+    raise AttributeError(name)

--- a/src/fateforger/agents/tasks/defaults_memory.py
+++ b/src/fateforger/agents/tasks/defaults_memory.py
@@ -9,7 +9,7 @@ import threading
 from dataclasses import dataclass
 from datetime import datetime, timezone
 from pathlib import Path
-from typing import Any, Literal
+from typing import Any, ClassVar, Literal
 
 from pydantic import BaseModel, Field
 
@@ -28,6 +28,12 @@ logger = logging.getLogger(__name__)
 _DEFAULTS_TOPIC = "taskmarshal-defaults"
 _DEFAULTS_NAME_PREFIX = "taskmarshal-defaults:"
 _DEFAULTS_DESC_PREFIX = "task_defaults_json:"
+_TASK_DEFAULTS_BACKENDS = {
+    "constraint_mcp",
+    "mem0",
+    "disabled",
+    "inherit_timeboxing",
+}
 
 
 class TaskDueDefaults(BaseModel):
@@ -47,11 +53,16 @@ class TaskDefaultsMemoryStore:
     """Adapter that stores task defaults in the shared durable-memory backend."""
 
     timeout_s: float = 10.0
+    _backend_mode_lock: ClassVar[threading.Lock] = threading.Lock()
+    _reported_fallback_modes: ClassVar[set[tuple[str, str, str]]] = set()
+    _reported_durable_modes: ClassVar[set[tuple[str, str]]] = set()
 
     def __post_init__(self) -> None:
         self._client: Any | None = None
         self._store: DurableConstraintStore | None = None
+        self._backend = self._resolve_backend()
         self._unavailable_reason: str | None = None
+        self._unavailable_reason_code: str | None = None
         self._fallback_path = Path(
             os.getenv("TASKS_DEFAULTS_CACHE_PATH", "logs/taskmarshal_defaults_cache.json")
         )
@@ -65,27 +76,26 @@ class TaskDefaultsMemoryStore:
             return self._store
         if self._unavailable_reason:
             return None
-        backend = str(getattr(settings, "timeboxing_memory_backend", "constraint_mcp"))
-        backend = backend.strip().lower()
+        if self._backend == "disabled":
+            self._unavailable_reason = "tasks defaults durable backend disabled by configuration"
+            self._unavailable_reason_code = "backend_disabled"
+            return None
         try:
-            if backend == "constraint_mcp":
+            if self._backend == "constraint_mcp":
                 self._client = ConstraintMemoryClient(timeout=self.timeout_s)
-            elif backend == "mem0":
+            elif self._backend == "mem0":
                 user_id = (
                     str(getattr(settings, "mem0_user_id", "") or "").strip()
                     or "timeboxing"
                 )
                 self._client = build_mem0_client_from_settings(user_id=user_id)
             else:
-                raise ValueError(f"Unsupported timeboxing memory backend: {backend}")
+                raise ValueError(f"Unsupported tasks defaults memory backend: {self._backend}")
             self._store = build_durable_constraint_store(self._client)
             self._unavailable_reason = None
+            self._unavailable_reason_code = None
         except Exception as exc:
-            self._unavailable_reason = f"{type(exc).__name__}: {exc}"
-            logger.warning(
-                "Task defaults durable memory unavailable (%s)",
-                self._unavailable_reason,
-            )
+            self._mark_store_unavailable(exc)
             return None
         return self._store
 
@@ -96,8 +106,18 @@ class TaskDefaultsMemoryStore:
             return cached
         store = self._ensure_store()
         if not store:
+            self._report_backend_mode(
+                user_id=user_id,
+                operation="get_user_defaults",
+                mode="fallback_cache",
+            )
             self._refresh_local_cache_from_disk()
             return self._local_defaults_by_user.get(user_id)
+        self._report_backend_mode(
+            user_id=user_id,
+            operation="get_user_defaults",
+            mode="durable",
+        )
         uid = self._uid_for_user(user_id)
         try:
             exact = await store.get_constraint(uid=uid)
@@ -116,10 +136,14 @@ class TaskDefaultsMemoryStore:
                 limit=20,
             )
         except Exception as exc:
-            logger.warning(
-                "Task defaults lookup failed (%s: %s)", type(exc).__name__, exc
+            self._mark_store_unavailable(exc)
+            self._report_backend_mode(
+                user_id=user_id,
+                operation="get_user_defaults",
+                mode="fallback_cache",
             )
-            return None
+            self._refresh_local_cache_from_disk()
+            return self._local_defaults_by_user.get(user_id)
         for row in rows:
             parsed = self._parse_entry_to_defaults(entry=row, user_id=user_id)
             if parsed is not None:
@@ -133,7 +157,17 @@ class TaskDefaultsMemoryStore:
         self._write_defaults_to_disk(defaults)
         store = self._ensure_store()
         if not store:
+            self._report_backend_mode(
+                user_id=defaults.user_id,
+                operation="upsert_user_defaults",
+                mode="fallback_cache",
+            )
             return True
+        self._report_backend_mode(
+            user_id=defaults.user_id,
+            operation="upsert_user_defaults",
+            mode="durable",
+        )
         payload = defaults.model_dump(mode="json")
         record = {
             "constraint_record": {
@@ -176,8 +210,11 @@ class TaskDefaultsMemoryStore:
                 },
             )
         except Exception as exc:
-            logger.warning(
-                "Task defaults upsert failed (%s: %s)", type(exc).__name__, exc
+            self._mark_store_unavailable(exc)
+            self._report_backend_mode(
+                user_id=defaults.user_id,
+                operation="upsert_user_defaults",
+                mode="fallback_cache",
             )
             return True
         return bool((result or {}).get("uid"))
@@ -185,6 +222,85 @@ class TaskDefaultsMemoryStore:
     @staticmethod
     def _uid_for_user(user_id: str) -> str:
         return f"taskmarshal-defaults:{user_id}"
+
+    @staticmethod
+    def _resolve_backend() -> str:
+        configured = str(
+            getattr(settings, "tasks_defaults_memory_backend", "constraint_mcp") or ""
+        ).strip().lower()
+        if not configured:
+            configured = "constraint_mcp"
+        if configured == "inherit_timeboxing":
+            configured = str(
+                getattr(settings, "timeboxing_memory_backend", "constraint_mcp") or ""
+            ).strip().lower() or "constraint_mcp"
+        if configured not in _TASK_DEFAULTS_BACKENDS:
+            return "disabled"
+        if configured == "inherit_timeboxing":
+            return "constraint_mcp"
+        return configured
+
+    @staticmethod
+    def _classify_unavailable_reason(exc: Exception) -> str:
+        message = str(exc).lower()
+        if "openai_api_key" in message:
+            return "missing_openai_api_key"
+        if "mem0_api_key" in message:
+            return "missing_mem0_api_key"
+        if "mem0 backend requires" in message:
+            return "missing_mem0_runtime_config"
+        if "notion_timeboxing_parent_page_id" in message:
+            return "missing_notion_parent_page_id"
+        if "notion_token" in message:
+            return "missing_notion_token"
+        if isinstance(exc, ValueError):
+            return "invalid_backend_config"
+        return "backend_unavailable"
+
+    def _mark_store_unavailable(self, exc: Exception) -> None:
+        self._store = None
+        self._client = None
+        self._unavailable_reason = f"{type(exc).__name__}: {exc}"
+        self._unavailable_reason_code = self._classify_unavailable_reason(exc)
+
+    def _report_backend_mode(
+        self,
+        *,
+        user_id: str,
+        operation: str,
+        mode: Literal["durable", "fallback_cache"],
+    ) -> None:
+        clean_user_id = str(user_id or "").strip()
+        if not clean_user_id:
+            return
+        if mode == "durable":
+            key = (self._backend, clean_user_id)
+            with self._backend_mode_lock:
+                if key in self._reported_durable_modes:
+                    return
+                self._reported_durable_modes.add(key)
+            logger.info(
+                "Task defaults backend mode=durable backend=%s user_id=%s operation=%s",
+                self._backend,
+                clean_user_id,
+                operation,
+            )
+            return
+
+        reason_code = self._unavailable_reason_code or "backend_unavailable"
+        key = (self._backend, reason_code, clean_user_id)
+        with self._backend_mode_lock:
+            if key in self._reported_fallback_modes:
+                return
+            self._reported_fallback_modes.add(key)
+        logger.warning(
+            "Task defaults backend mode=fallback_cache backend=%s reason_code=%s user_id=%s operation=%s reason=%s",
+            self._backend,
+            reason_code,
+            clean_user_id,
+            operation,
+            self._unavailable_reason or "n/a",
+        )
 
     @staticmethod
     def _parse_entry_to_defaults(

--- a/src/fateforger/core/config.py
+++ b/src/fateforger/core/config.py
@@ -193,6 +193,7 @@ class Settings(BaseSettings):
     timeboxing_memory_backend: str = Field(
         default="constraint_mcp"
     )
+    tasks_defaults_memory_backend: str = Field(default="constraint_mcp")
 
     # Mem0 Memory Configuration
     mem0_user_id: str = Field(default="timeboxing")
@@ -269,6 +270,17 @@ class Settings(BaseSettings):
             "TIMEBOXING_MEMORY_BACKEND must be one of: constraint_mcp, mem0"
         )
 
+    @field_validator("tasks_defaults_memory_backend")
+    @classmethod
+    def _validate_tasks_defaults_memory_backend(cls, value: str) -> str:
+        backend = (value or "").strip().lower()
+        if backend in {"constraint_mcp", "mem0", "disabled", "inherit_timeboxing"}:
+            return backend
+        raise ValueError(
+            "TASKS_DEFAULTS_MEMORY_BACKEND must be one of: "
+            "constraint_mcp, mem0, disabled, inherit_timeboxing"
+        )
+
     @field_validator("autogen_events_log")
     @classmethod
     def _validate_autogen_events_log(cls, value: str) -> str:
@@ -340,7 +352,14 @@ class Settings(BaseSettings):
     def _validate_runtime_invariants(self) -> "Settings":
         if not self.slack_socket_mode:
             raise ValueError("SLACK_SOCKET_MODE must remain enabled")
-        if self.timeboxing_memory_backend == "mem0":
+        needs_mem0_runtime = self.timeboxing_memory_backend == "mem0" or (
+            self.tasks_defaults_memory_backend == "mem0"
+        )
+        if self.tasks_defaults_memory_backend == "inherit_timeboxing":
+            needs_mem0_runtime = needs_mem0_runtime or (
+                self.timeboxing_memory_backend == "mem0"
+            )
+        if needs_mem0_runtime:
             local_config = (self.mem0_local_config_json or "").strip()
             has_local_runtime = bool(local_config)
             has_cloud_runtime = bool(self.mem0_is_cloud and self.mem0_api_key.strip())

--- a/src/fateforger/tools/mcp_url_validation.py
+++ b/src/fateforger/tools/mcp_url_validation.py
@@ -6,7 +6,7 @@ import os
 import socket
 from dataclasses import dataclass
 from typing import Mapping
-from urllib.parse import ParseResult, urlparse
+from urllib.parse import ParseResult, urlparse, urlunparse
 
 
 def _validate_url(
@@ -29,6 +29,26 @@ def _validate_url(
     if require_explicit_path and (not parsed.path or parsed.path == "/"):
         raise ValueError(f"{label} must include explicit path (e.g. /mcp)")
     return raw, parsed
+
+
+def rewrite_mcp_host(
+    value: str,
+    host: str,
+    *,
+    default_path: str = "/mcp",
+) -> str:
+    """Rewrite only host/port while preserving scheme/query and ensuring a path."""
+    if not (host or "").strip():
+        raise ValueError("rewrite_mcp_host requires a non-empty host")
+    raw, parsed = _validate_url(
+        value,
+        label="MCP URL",
+        require_explicit_path=False,
+    )
+    port = parsed.port or (443 if parsed.scheme == "https" else 80)
+    path = parsed.path if parsed.path and parsed.path != "/" else default_path
+    replaced = parsed._replace(netloc=f"{host.strip()}:{port}", path=path)
+    return urlunparse(replaced)
 
 
 @dataclass(frozen=True)
@@ -140,4 +160,5 @@ __all__ = [
     "McpEndpointResolver",
     "NotionMcpEndpointResolver",
     "TickTickMcpEndpointResolver",
+    "rewrite_mcp_host",
 ]

--- a/src/fateforger/tools/notion_mcp.py
+++ b/src/fateforger/tools/notion_mcp.py
@@ -19,6 +19,11 @@ def validate_notion_mcp_url(value: str) -> str:
     return _NOTION_ENDPOINT.validate(value)
 
 
+def normalize_notion_mcp_url(value: str) -> str:
+    """Normalize/validate Notion MCP URL used by runtime clients."""
+    return validate_notion_mcp_url(value)
+
+
 def probe_notion_mcp_endpoint(
     server_url: str, *, connect_timeout_s: float = 1.0
 ) -> tuple[bool, str | None]:
@@ -55,6 +60,7 @@ __all__ = [
     "NotionMcpClient",
     "get_notion_mcp_headers",
     "get_notion_mcp_url",
+    "normalize_notion_mcp_url",
     "validate_notion_mcp_url",
     "probe_notion_mcp_endpoint",
 ]

--- a/src/fateforger/tools/ticktick_mcp.py
+++ b/src/fateforger/tools/ticktick_mcp.py
@@ -5,6 +5,8 @@ TickTick Tools Configuration - MCP server parameters and tool loader.
 from __future__ import annotations
 
 import os
+from urllib.parse import urlparse
+
 from fateforger.tools.mcp_http_client import StreamableHttpMcpClient
 from fateforger.tools.mcp_url_validation import TickTickMcpEndpointResolver
 
@@ -18,6 +20,34 @@ def get_ticktick_mcp_url() -> str:
 
 def validate_ticktick_mcp_url(value: str) -> str:
     return _TICKTICK_ENDPOINT.validate(value)
+
+
+def normalize_ticktick_mcp_url(value: str) -> str:
+    """Normalize/validate TickTick MCP URL used by runtime clients."""
+    return validate_ticktick_mcp_url(value)
+
+
+def ticktick_localhost_fallback_urls(server_url: str) -> list[str]:
+    """Return deterministic localhost candidates for docker-host fallback."""
+    validated = validate_ticktick_mcp_url(server_url)
+    parsed = urlparse(validated)
+    if (parsed.hostname or "").strip().lower() != "ticktick-mcp":
+        return []
+    path = parsed.path or "/mcp"
+    host_port = (os.getenv("TICKTICK_HOST_PORT") or "8002").strip() or "8002"
+    candidates = [
+        f"{parsed.scheme}://localhost:{host_port}{path}",
+        f"{parsed.scheme}://127.0.0.1:{host_port}{path}",
+        f"{parsed.scheme}://host.docker.internal:{host_port}{path}",
+    ]
+    out: list[str] = []
+    seen: set[str] = set()
+    for candidate in candidates:
+        if candidate in seen:
+            continue
+        seen.add(candidate)
+        out.append(candidate)
+    return out
 
 
 def probe_ticktick_mcp_endpoint(
@@ -51,6 +81,8 @@ class TickTickMcpClient(StreamableHttpMcpClient):
 __all__ = [
     "TickTickMcpClient",
     "get_ticktick_mcp_url",
+    "normalize_ticktick_mcp_url",
+    "ticktick_localhost_fallback_urls",
     "validate_ticktick_mcp_url",
     "probe_ticktick_mcp_endpoint",
 ]

--- a/tests/unit/test_mcp_url_validation.py
+++ b/tests/unit/test_mcp_url_validation.py
@@ -3,12 +3,14 @@ from __future__ import annotations
 import pytest
 
 from fateforger.tools.notion_mcp import (
+    normalize_notion_mcp_url,
     probe_notion_mcp_endpoint,
     validate_notion_mcp_url,
 )
 from fateforger.tools.mcp_url_validation import (
     NotionMcpEndpointResolver,
     TickTickMcpEndpointResolver,
+    rewrite_mcp_host,
 )
 from fateforger.tools.ticktick_mcp import (
     probe_ticktick_mcp_endpoint,
@@ -66,6 +68,11 @@ def test_validate_notion_mcp_url_does_not_normalize() -> None:
     assert validate_notion_mcp_url(configured) == configured
 
 
+def test_normalize_notion_mcp_url_matches_validator() -> None:
+    configured = "http://notion-mcp:3001/mcp?transport=sse"
+    assert normalize_notion_mcp_url(configured) == configured
+
+
 def test_probe_notion_mcp_endpoint_reports_validation_error() -> None:
     ok, reason = probe_notion_mcp_endpoint("notion-mcp:3001/mcp")
     assert ok is False
@@ -82,3 +89,20 @@ def test_ticktick_endpoint_resolver_prefers_explicit_env() -> None:
     resolver = TickTickMcpEndpointResolver()
     resolved = resolver.resolve({"TICKTICK_MCP_URL": "http://host:8000/mcp"})
     assert resolved == "http://host:8000/mcp"
+
+
+def test_rewrite_mcp_host_preserves_scheme_port_and_query() -> None:
+    rewritten = rewrite_mcp_host(
+        "https://notion-mcp:3443/mcp?transport=sse",
+        "localhost",
+    )
+    assert rewritten == "https://localhost:3443/mcp?transport=sse"
+
+
+def test_rewrite_mcp_host_adds_default_path_when_missing() -> None:
+    rewritten = rewrite_mcp_host(
+        "http://notion-mcp:3001",
+        "host.docker.internal",
+        default_path="/mcp",
+    )
+    assert rewritten == "http://host.docker.internal:3001/mcp"

--- a/tests/unit/test_task_defaults_memory.py
+++ b/tests/unit/test_task_defaults_memory.py
@@ -3,6 +3,19 @@ from __future__ import annotations
 import pytest
 
 from fateforger.agents.tasks.defaults_memory import TaskDefaultsMemoryStore, TaskDueDefaults
+from fateforger.core.config import settings
+
+
+@pytest.fixture(autouse=True)
+def _reset_backend_mode_tracking(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path,
+) -> None:
+    TaskDefaultsMemoryStore._reported_fallback_modes.clear()
+    TaskDefaultsMemoryStore._reported_durable_modes.clear()
+    monkeypatch.setenv(
+        "TASKS_DEFAULTS_CACHE_PATH", str(tmp_path / "task_defaults_cache.json")
+    )
 
 
 @pytest.mark.asyncio
@@ -30,3 +43,152 @@ async def test_disk_fallback_persists_across_store_instances(
     assert loaded is not None
     assert loaded.ticktick_project_ids == ["P1"]
     assert loaded.ticktick_project_names == ["tasks"]
+
+
+def test_backend_selection_defaults_to_task_specific_setting(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(settings, "timeboxing_memory_backend", "mem0", raising=False)
+    monkeypatch.setattr(
+        settings, "tasks_defaults_memory_backend", "constraint_mcp", raising=False
+    )
+    store = TaskDefaultsMemoryStore()
+    assert store._backend == "constraint_mcp"
+
+
+def test_backend_selection_can_inherit_timeboxing_backend(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(settings, "timeboxing_memory_backend", "mem0", raising=False)
+    monkeypatch.setattr(
+        settings, "tasks_defaults_memory_backend", "inherit_timeboxing", raising=False
+    )
+    store = TaskDefaultsMemoryStore()
+    assert store._backend == "mem0"
+
+
+@pytest.mark.asyncio
+async def test_missing_openai_key_falls_back_with_one_warning_per_user(
+    monkeypatch: pytest.MonkeyPatch,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    monkeypatch.setattr(settings, "tasks_defaults_memory_backend", "mem0", raising=False)
+    monkeypatch.setattr(
+        "fateforger.agents.tasks.defaults_memory.build_mem0_client_from_settings",
+        lambda user_id: (_ for _ in ()).throw(
+            RuntimeError("OPENAI_API_KEY is required for configured Mem0 model")
+        ),
+    )
+
+    caplog.set_level("WARNING")
+    store = TaskDefaultsMemoryStore()
+
+    first = await store.get_user_defaults(user_id="U1")
+    second = await store.get_user_defaults(user_id="U1")
+    third = await store.get_user_defaults(user_id="U2")
+
+    assert first is None
+    assert second is None
+    assert third is None
+    warning_lines = [
+        rec.message
+        for rec in caplog.records
+        if "backend mode=fallback_cache" in rec.message
+    ]
+    assert len(warning_lines) == 2
+    assert all("reason_code=missing_openai_api_key" in msg for msg in warning_lines)
+
+
+@pytest.mark.asyncio
+async def test_durable_backend_logs_mode_once_and_reads_constraint(
+    monkeypatch: pytest.MonkeyPatch,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    monkeypatch.setattr(
+        settings, "tasks_defaults_memory_backend", "constraint_mcp", raising=False
+    )
+
+    class _Store:
+        async def get_constraint(self, *, uid: str):
+            assert uid == "taskmarshal-defaults:U1"
+            return {
+                "constraint_record": {
+                    "name": "taskmarshal-defaults:U1",
+                    "description": (
+                        "task_defaults_json:{"
+                        '"user_id":"U1","source":"ticktick","ticktick_project_ids":["P1"],'
+                        '"ticktick_project_names":["tasks"],'
+                        '"configured_at":"2026-03-02T00:00:00+00:00"}'
+                    ),
+                }
+            }
+
+        async def query_constraints(
+            self,
+            *,
+            filters,
+            type_ids=None,
+            tags=None,
+            sort=None,
+            limit=50,
+        ):
+            _ = filters, type_ids, tags, sort, limit
+            return []
+
+    store = TaskDefaultsMemoryStore()
+    monkeypatch.setattr(store, "_ensure_store", lambda: _Store())
+    caplog.set_level("INFO")
+
+    loaded_first = await store.get_user_defaults(user_id="U1")
+    loaded_second = await store.get_user_defaults(user_id="U1")
+
+    assert loaded_first is not None
+    assert loaded_second is not None
+    assert loaded_first.ticktick_project_ids == ["P1"]
+    durable_lines = [
+        rec.message for rec in caplog.records if "backend mode=durable" in rec.message
+    ]
+    assert len(durable_lines) == 1
+
+
+@pytest.mark.asyncio
+async def test_runtime_durable_lookup_failure_downgrades_to_fallback_once(
+    monkeypatch: pytest.MonkeyPatch,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    monkeypatch.setattr(
+        settings, "tasks_defaults_memory_backend", "constraint_mcp", raising=False
+    )
+
+    class _FailingStore:
+        async def get_constraint(self, *, uid: str):
+            _ = uid
+            raise RuntimeError("NOTION_TIMEBOXING_PARENT_PAGE_ID is not accessible")
+
+        async def query_constraints(
+            self,
+            *,
+            filters,
+            type_ids=None,
+            tags=None,
+            sort=None,
+            limit=50,
+        ):
+            _ = filters, type_ids, tags, sort, limit
+            raise RuntimeError("NOTION_TIMEBOXING_PARENT_PAGE_ID is not accessible")
+
+    store = TaskDefaultsMemoryStore()
+    store._store = _FailingStore()
+    caplog.set_level("WARNING")
+
+    first = await store.get_user_defaults(user_id="U1")
+    second = await store.get_user_defaults(user_id="U1")
+
+    assert first is None
+    assert second is None
+    fallback_lines = [
+        rec.message
+        for rec in caplog.records
+        if "backend mode=fallback_cache" in rec.message
+    ]
+    assert len(fallback_lines) == 1


### PR DESCRIPTION
## Summary
- make task defaults memory backend explicit (`TASKS_DEFAULTS_MEMORY_BACKEND`) with options:
  - `constraint_mcp` (default)
  - `mem0`
  - `disabled`
  - `inherit_timeboxing`
- remove repeated warning noise by downgrading durable lookup/upsert failures into cached fallback mode with one structured warning per `user+reason`
- add deterministic backend-mode observability logs (`durable` / `fallback_cache`)
- document backend/fallback behavior in Tasks README and `.env.template`

## Additional baseline compatibility fixes
- restore missing MCP URL helper functions referenced by task tooling:
  - `normalize_ticktick_mcp_url`
  - `ticktick_localhost_fallback_urls`
  - `normalize_notion_mcp_url`
  - `rewrite_mcp_host`
- add/extend unit coverage for these helpers

## Validation
- `PYTHONPATH=/Users/hugoevers/VScode-projects/admonish-1-issue63/src:/Users/hugoevers/VScode-projects/admonish-1-issue63 /Users/hugoevers/VScode-projects/admonish-1/.venv/bin/python -m pytest tests/unit/test_task_defaults_memory.py tests/unit/test_mcp_url_validation.py tests/unit/test_tasks_ticktick_list_tools.py -q`
- result: `43 passed`
- live Slack audit (task-marshalling): due-task query replayed; fallback warning logged once for repeated identical failure reason and not repeated on immediate retry.
- Prometheus checks: scrape up, no route timeout/error spikes in audit window.

Closes #63
