### PR TITLE
#69: canonicalize shared constraint mirror and add prune API

### DIFF
--- a/src/fateforger/agents/timeboxing/agent.py
+++ b/src/fateforger/agents/timeboxing/agent.py
@@ -1411,12 +1411,20 @@ class TimeboxingFlowAgent(RoutedAgent):
                                 except Exception:
                                     pass
                     if self._constraint_store:
-                        await self._constraint_store.add_constraints(
-                            user_id=session.user_id,
-                            channel_id=session.channel_id,
-                            thread_ts=session.thread_ts,
-                            constraints=constraints,
-                        )
+                        if hasattr(self._constraint_store, "upsert_constraints"):
+                            await self._constraint_store.upsert_constraints(
+                                user_id=session.user_id,
+                                channel_id=session.channel_id,
+                                thread_ts=session.thread_ts,
+                                constraints=constraints,
+                            )
+                        else:
+                            await self._constraint_store.add_constraints(
+                                user_id=session.user_id,
+                                channel_id=session.channel_id,
+                                thread_ts=session.thread_ts,
+                                constraints=constraints,
+                            )
                         self._session_debug(
                             session,
                             "constraint_local_persisted",
@@ -6091,13 +6099,47 @@ class TimeboxingFlowAgent(RoutedAgent):
                 }
             )
             to_add.append(ConstraintBase.model_validate(payload))
+        upsert_added = 0
+        upsert_skipped = 0
         if to_add:
-            await self._constraint_store.add_constraints(
+            if hasattr(self._constraint_store, "upsert_constraints"):
+                outcome = await self._constraint_store.upsert_constraints(
+                    user_id=session.user_id,
+                    channel_id=session.channel_id,
+                    thread_ts=session.thread_ts,
+                    constraints=to_add,
+                )
+                upsert_added = int((outcome or {}).get("added") or 0)
+                upsert_skipped = int((outcome or {}).get("skipped") or 0)
+            else:
+                await self._constraint_store.add_constraints(
+                    user_id=session.user_id,
+                    channel_id=session.channel_id,
+                    thread_ts=session.thread_ts,
+                    constraints=to_add,
+                )
+                upsert_added = len(to_add)
+
+        prune_preview: dict[str, Any] = {}
+        if hasattr(self._constraint_store, "prune_shared_constraints"):
+            prune_preview = await self._constraint_store.prune_shared_constraints(
                 user_id=session.user_id,
                 channel_id=session.channel_id,
-                thread_ts=session.thread_ts,
-                constraints=to_add,
+                dry_run=True,
             )
+        self._session_debug(
+            session,
+            "shared_constraint_mirror_snapshot",
+            mirrored_total=len(to_add),
+            mirrored_added=upsert_added,
+            mirrored_skipped=upsert_skipped,
+            raw_shared_rows=int((prune_preview or {}).get("raw_shared_rows") or 0),
+            canonical_shared_rows=int(
+                (prune_preview or {}).get("canonical_shared_rows") or 0
+            ),
+            duplicate_groups=int((prune_preview or {}).get("duplicate_groups") or 0),
+            duplicates_found=int((prune_preview or {}).get("duplicates_found") or 0),
+        )
 
     async def _publish_update(
         self,

--- a/src/fateforger/agents/timeboxing/preferences.py
+++ b/src/fateforger/agents/timeboxing/preferences.py
@@ -131,6 +131,110 @@ class ConstraintStore:
                 await session.refresh(row)
         return rows
 
+    async def upsert_constraints(
+        self,
+        *,
+        user_id: str,
+        channel_id: Optional[str],
+        thread_ts: Optional[str],
+        constraints: List[ConstraintBase],
+    ) -> Dict[str, int]:
+        """Persist constraints while avoiding duplicate shared-scope inserts."""
+        if not constraints:
+            return {"added": 0, "skipped": 0, "total": 0}
+        async with self._sessionmaker() as session:
+            stmt = select(Constraint).where(Constraint.user_id == user_id)
+            if channel_id:
+                stmt = stmt.where(Constraint.channel_id == channel_id)
+            result = await session.execute(stmt)
+            existing_rows = list(result.scalars().all())
+            seen_keys = {_constraint_row_identity(row) for row in existing_rows}
+
+            to_add: list[Constraint] = []
+            skipped = 0
+            for constraint in constraints:
+                scope = constraint.scope or ConstraintScope.SESSION
+                target_thread_ts = (
+                    None
+                    if scope in (ConstraintScope.PROFILE, ConstraintScope.DATESPAN)
+                    else thread_ts
+                )
+                row = _constraint_row(
+                    constraint,
+                    user_id=user_id,
+                    channel_id=channel_id,
+                    thread_ts=target_thread_ts,
+                )
+                key = _constraint_row_identity(row)
+                if key in seen_keys:
+                    skipped += 1
+                    continue
+                seen_keys.add(key)
+                to_add.append(row)
+
+            if to_add:
+                session.add_all(to_add)
+                await session.commit()
+                for row in to_add:
+                    await session.refresh(row)
+            return {"added": len(to_add), "skipped": skipped, "total": len(constraints)}
+
+    async def prune_shared_constraints(
+        self,
+        *,
+        user_id: str,
+        channel_id: Optional[str] = None,
+        dry_run: bool = True,
+    ) -> Dict[str, Any]:
+        """Deduplicate shared-scope constraints by canonical precedence."""
+        async with self._sessionmaker() as session:
+            stmt = select(Constraint).where(
+                Constraint.user_id == user_id,
+                or_(
+                    Constraint.scope == ConstraintScope.PROFILE,
+                    Constraint.scope == ConstraintScope.DATESPAN,
+                ),
+            )
+            if channel_id:
+                stmt = stmt.where(Constraint.channel_id == channel_id)
+            result = await session.execute(stmt)
+            rows = list(result.scalars().all())
+
+            groups: Dict[str, List[Constraint]] = {}
+            for row in rows:
+                groups.setdefault(_shared_constraint_identity(row), []).append(row)
+
+            canonical_by_group: Dict[str, Constraint] = {}
+            duplicate_rows: list[Constraint] = []
+            duplicate_groups = 0
+            for key, items in groups.items():
+                canonical = max(items, key=_shared_canonical_sort_key)
+                canonical_by_group[key] = canonical
+                duplicates = [row for row in items if row.id != canonical.id]
+                if duplicates:
+                    duplicate_groups += 1
+                    duplicate_rows.extend(duplicates)
+
+            pruned = 0
+            if not dry_run and duplicate_rows:
+                for row in duplicate_rows:
+                    await session.delete(row)
+                    pruned += 1
+                await session.commit()
+
+            return {
+                "dry_run": dry_run,
+                "raw_shared_rows": len(rows),
+                "canonical_shared_rows": len(canonical_by_group),
+                "duplicate_groups": duplicate_groups,
+                "duplicates_found": len(duplicate_rows),
+                "duplicates_pruned": pruned,
+                "canonical_statuses_by_identity": {
+                    key: _status_text(value.status)
+                    for key, value in canonical_by_group.items()
+                },
+            }
+
     async def list_constraints(
         self,
         *,
@@ -257,6 +361,51 @@ def _constraint_row(
         channel_id=channel_id,
         thread_ts=thread_ts,
     )
+
+
+def _status_rank(status: Optional[ConstraintStatus]) -> int:
+    if status == ConstraintStatus.LOCKED:
+        return 3
+    if status == ConstraintStatus.PROPOSED:
+        return 2
+    if status == ConstraintStatus.DECLINED:
+        return 1
+    return 0
+
+
+def _status_text(status: Optional[ConstraintStatus]) -> str:
+    if isinstance(status, ConstraintStatus):
+        return status.value
+    return str(status or "")
+
+
+def _shared_canonical_sort_key(row: Constraint) -> tuple[int, float, float, int]:
+    updated = row.updated_at.timestamp() if row.updated_at else 0.0
+    created = row.created_at.timestamp() if row.created_at else 0.0
+    return (_status_rank(row.status), updated, created, int(row.id or 0))
+
+
+def _shared_constraint_identity(row: Constraint) -> str:
+    return _constraint_row_identity(row, include_thread=False)
+
+
+def _constraint_row_identity(row: Constraint, *, include_thread: bool = True) -> str:
+    hints = row.hints if isinstance(row.hints, dict) else {}
+    uid = str(hints.get("uid") or "").strip().lower()
+    scope = row.scope if isinstance(row.scope, ConstraintScope) else ConstraintScope.SESSION
+    channel = str(row.channel_id or "").strip().lower()
+    necessity = (
+        row.necessity.value
+        if isinstance(row.necessity, ConstraintNecessity)
+        else str(row.necessity or "").strip().lower()
+    )
+    name = str(row.name or "").strip().lower()
+    description = str(row.description or "").strip().lower()
+    base = uid or "|".join([name, description, necessity, scope.value])
+    if include_thread and scope == ConstraintScope.SESSION:
+        thread = str(row.thread_ts or "").strip().lower()
+        return f"session|{channel}|{thread}|{base}"
+    return f"shared|{channel}|{scope.value}|{base}"
 
 
 __all__ = [

--- a/tests/unit/test_timeboxing_constraint_store_canonicalization.py
+++ b/tests/unit/test_timeboxing_constraint_store_canonicalization.py
@@ -1,0 +1,158 @@
+from __future__ import annotations
+
+import pytest
+from sqlalchemy.ext.asyncio import async_sessionmaker, create_async_engine
+
+from fateforger.agents.timeboxing.preferences import (
+    ConstraintBase,
+    ConstraintNecessity,
+    ConstraintScope,
+    ConstraintSource,
+    ConstraintStatus,
+    ConstraintStore,
+    ensure_constraint_schema,
+)
+
+
+def _shared_constraint(*, status: ConstraintStatus) -> ConstraintBase:
+    return ConstraintBase(
+        name="No calls after 17:00",
+        description="Protect evening deep work.",
+        necessity=ConstraintNecessity.SHOULD,
+        status=status,
+        source=ConstraintSource.USER,
+        scope=ConstraintScope.PROFILE,
+        hints={"uid": "uid:no_calls_after_17"},
+    )
+
+
+@pytest.mark.asyncio
+async def test_upsert_constraints_dedupes_shared_scope_across_threads() -> None:
+    engine = create_async_engine("sqlite+aiosqlite:///:memory:")
+    try:
+        await ensure_constraint_schema(engine)
+        store = ConstraintStore(async_sessionmaker(engine, expire_on_commit=False))
+
+        first = await store.upsert_constraints(
+            user_id="u1",
+            channel_id="c1",
+            thread_ts="t1",
+            constraints=[_shared_constraint(status=ConstraintStatus.PROPOSED)],
+        )
+        second = await store.upsert_constraints(
+            user_id="u1",
+            channel_id="c1",
+            thread_ts="t2",
+            constraints=[_shared_constraint(status=ConstraintStatus.PROPOSED)],
+        )
+
+        rows = await store.list_constraints(
+            user_id="u1",
+            channel_id="c1",
+            scope=ConstraintScope.PROFILE,
+        )
+        assert first["added"] == 1
+        assert second["added"] == 0
+        assert second["skipped"] == 1
+        assert len(rows) == 1
+        assert rows[0].thread_ts is None
+    finally:
+        await engine.dispose()
+
+
+@pytest.mark.asyncio
+async def test_prune_shared_constraints_dry_run_reports_without_mutation() -> None:
+    engine = create_async_engine("sqlite+aiosqlite:///:memory:")
+    try:
+        await ensure_constraint_schema(engine)
+        store = ConstraintStore(async_sessionmaker(engine, expire_on_commit=False))
+
+        await store.add_constraints(
+            user_id="u1",
+            channel_id="c1",
+            thread_ts="t1",
+            constraints=[_shared_constraint(status=ConstraintStatus.PROPOSED)],
+        )
+        await store.add_constraints(
+            user_id="u1",
+            channel_id="c1",
+            thread_ts="t2",
+            constraints=[_shared_constraint(status=ConstraintStatus.LOCKED)],
+        )
+        await store.add_constraints(
+            user_id="u1",
+            channel_id="c1",
+            thread_ts="t3",
+            constraints=[_shared_constraint(status=ConstraintStatus.DECLINED)],
+        )
+
+        before = await store.list_constraints(
+            user_id="u1",
+            channel_id="c1",
+            scope=ConstraintScope.PROFILE,
+        )
+        preview = await store.prune_shared_constraints(
+            user_id="u1",
+            channel_id="c1",
+            dry_run=True,
+        )
+        after = await store.list_constraints(
+            user_id="u1",
+            channel_id="c1",
+            scope=ConstraintScope.PROFILE,
+        )
+
+        assert len(before) == 3
+        assert len(after) == 3
+        assert preview["raw_shared_rows"] == 3
+        assert preview["canonical_shared_rows"] == 1
+        assert preview["duplicates_found"] == 2
+        assert preview["duplicates_pruned"] == 0
+        assert set(preview["canonical_statuses_by_identity"].values()) == {"locked"}
+    finally:
+        await engine.dispose()
+
+
+@pytest.mark.asyncio
+async def test_prune_shared_constraints_apply_keeps_single_canonical_row() -> None:
+    engine = create_async_engine("sqlite+aiosqlite:///:memory:")
+    try:
+        await ensure_constraint_schema(engine)
+        store = ConstraintStore(async_sessionmaker(engine, expire_on_commit=False))
+
+        await store.add_constraints(
+            user_id="u1",
+            channel_id="c1",
+            thread_ts="t1",
+            constraints=[_shared_constraint(status=ConstraintStatus.PROPOSED)],
+        )
+        await store.add_constraints(
+            user_id="u1",
+            channel_id="c1",
+            thread_ts="t2",
+            constraints=[_shared_constraint(status=ConstraintStatus.LOCKED)],
+        )
+        await store.add_constraints(
+            user_id="u1",
+            channel_id="c1",
+            thread_ts="t3",
+            constraints=[_shared_constraint(status=ConstraintStatus.DECLINED)],
+        )
+
+        apply_result = await store.prune_shared_constraints(
+            user_id="u1",
+            channel_id="c1",
+            dry_run=False,
+        )
+        remaining = await store.list_constraints(
+            user_id="u1",
+            channel_id="c1",
+            scope=ConstraintScope.PROFILE,
+        )
+
+        assert apply_result["duplicates_found"] == 2
+        assert apply_result["duplicates_pruned"] == 2
+        assert len(remaining) == 1
+        assert remaining[0].status == ConstraintStatus.LOCKED
+    finally:
+        await engine.dispose()


### PR DESCRIPTION
## Summary
Implements the first #69 slice for shared constraint mirror stabilization:

- Adds `ConstraintStore.upsert_constraints(...)` to prevent duplicate shared-scope mirror inserts across threads.
- Adds `ConstraintStore.prune_shared_constraints(..., dry_run)` with deterministic canonical precedence.
- Wires timeboxing local mirror paths to use upsert behavior when available.
- Emits structured session debug snapshot for shared mirror/canonicalization counts.

## Canonical precedence
For duplicate shared identities, canonical row is selected by:
1. status rank (`LOCKED > PROPOSED > DECLINED`)
2. latest `updated_at`
3. latest `created_at`
4. highest `id` as stable tie-breaker

## Tests
Added:
- `tests/unit/test_timeboxing_constraint_store_canonicalization.py`
  - dedupe shared scope across threads
  - dry-run prune reporting and non-mutation
  - apply prune keeping one canonical row

Ran:
- `tests/unit/test_timeboxing_constraint_store_canonicalization.py`
- `tests/unit/test_timeboxing_durable_constraints.py`
- `tests/unit/test_timeboxing_constraint_extraction_background.py`
- `tests/unit/test_timeboxing_constraint_selection.py`
- `tests/unit/test_timeboxing_session_init_order.py`

## Tracking
- Closes part of #69
- Epic: #74
