### PR TITLE
Timeboxing: one-turn explicit commit submit + idempotent resubmit no-op

### DIFF
--- a/src/fateforger/agents/timeboxing/agent.py
+++ b/src/fateforger/agents/timeboxing/agent.py
@@ -151,6 +151,7 @@ from .sync_engine import (
     FFTB_PREFIX,
     SyncTransaction,
     gcal_response_to_tb_plan_with_identity,
+    plan_sync,
 )
 from .task_marshalling_capability import TaskMarshallingCapability
 from .tb_models import TBEvent, TBPlan
@@ -6449,31 +6450,44 @@ class TimeboxingFlowAgent(RoutedAgent):
                 await self._scheduler_prefetch.ensure_collect_stage_ready(
                     session=session
                 )
-            if (
-                session.stage == TimeboxingStage.REVIEW_COMMIT
-                and session.pending_submit
+            decision: StageDecision | None = None
+            if session.stage in (
+                TimeboxingStage.REFINE,
+                TimeboxingStage.REVIEW_COMMIT,
             ):
                 decision = await self._decide_next_action(
                     session,
                     user_message=message.text,
                 )
-                if decision.action == "proceed":
-                    self._session_debug(
-                        session,
-                        "nl_submit_from_reply",
-                        decision_action=decision.action,
-                    )
-                    submit_reply = await self._submit_pending_plan(session=session)
-                    await self._publish_update(
-                        session=session,
-                        user_message=(
-                            submit_reply.content
-                            if isinstance(submit_reply, TextMessage)
-                            else submit_reply.text
-                        ),
-                        actions=[],
-                    )
-                    return submit_reply
+            if (
+                session.stage == TimeboxingStage.REVIEW_COMMIT
+                and session.pending_submit
+                and decision is not None
+                and decision.action == "proceed"
+                and decision.submit_intent
+            ):
+                self._session_debug(
+                    session,
+                    "nl_submit_from_reply",
+                    decision_action=decision.action,
+                    submit_mode="auto_nl",
+                    submit_attempt_kind=self._submit_attempt_kind(session),
+                )
+                submit_reply = await self._submit_pending_plan(
+                    session=session,
+                    submit_mode="auto_nl",
+                    submit_attempt_kind=self._submit_attempt_kind(session),
+                )
+                await self._publish_update(
+                    session=session,
+                    user_message=(
+                        submit_reply.content
+                        if isinstance(submit_reply, TextMessage)
+                        else submit_reply.text
+                    ),
+                    actions=[],
+                )
+                return submit_reply
             memory_reply = await self._maybe_handle_memory_review_turn(
                 session=session,
                 user_message=message.text,
@@ -6498,6 +6512,45 @@ class TimeboxingFlowAgent(RoutedAgent):
                 reply=reply, session=session
             )
             outgoing = self._attach_presenter_blocks(reply=wrapped, session=session)
+            if (
+                decision is not None
+                and decision.submit_intent
+                and session.stage == TimeboxingStage.REVIEW_COMMIT
+            ):
+                if (
+                    session.pending_submit
+                    and session.tb_plan is not None
+                    and session.base_snapshot is not None
+                ):
+                    self._session_debug(
+                        session,
+                        "nl_submit_from_reply",
+                        decision_action=decision.action,
+                        submit_mode="auto_nl",
+                        submit_attempt_kind=self._submit_attempt_kind(session),
+                    )
+                    submit_reply = await self._submit_pending_plan(
+                        session=session,
+                        submit_mode="auto_nl",
+                        submit_attempt_kind=self._submit_attempt_kind(session),
+                    )
+                    await self._publish_update(
+                        session=session,
+                        user_message=(
+                            submit_reply.content
+                            if isinstance(submit_reply, TextMessage)
+                            else submit_reply.text
+                        ),
+                        actions=[],
+                    )
+                    return submit_reply
+                not_ready_reply = self._build_submit_incomplete_reply()
+                await self._publish_update(
+                    session=session,
+                    user_message=not_ready_reply.content,
+                    actions=[],
+                )
+                return not_ready_reply
             await self._publish_update(
                 session=session,
                 user_message=(
@@ -6739,12 +6792,30 @@ class TimeboxingFlowAgent(RoutedAgent):
                 content="This session has already ended; submission is no longer available.",
                 source=self._agent_source(),
             )
-        return await self._submit_pending_plan(session=session)
+        return await self._submit_pending_plan(
+            session=session,
+            submit_mode="manual_button",
+            submit_attempt_kind=self._submit_attempt_kind(session),
+        )
+
+    @staticmethod
+    def _submit_attempt_kind(session: Session) -> Literal["first_submit", "resubmit"]:
+        """Return submit attempt kind for telemetry and UX clarity."""
+        return "resubmit" if session.last_sync_transaction is not None else "first_submit"
+
+    def _build_submit_incomplete_reply(self) -> TextMessage:
+        """Return deterministic copy when submit is requested before prerequisites exist."""
+        return TextMessage(
+            content="Cannot submit yet because the plan is incomplete. Please refine first.",
+            source=self._agent_source(),
+        )
 
     async def _submit_pending_plan(
         self,
         *,
         session: Session,
+        submit_mode: Literal["auto_nl", "manual_button"],
+        submit_attempt_kind: Literal["first_submit", "resubmit"],
     ) -> TextMessage | SlackBlockMessage:
         """Submit the pending Stage 5 plan to calendar when ready."""
         if not session.pending_submit:
@@ -6752,6 +6823,8 @@ class TimeboxingFlowAgent(RoutedAgent):
                 session,
                 "submission_skipped",
                 reason="not_pending_submit",
+                submit_mode=submit_mode,
+                submit_attempt_kind=submit_attempt_kind,
             )
             return TextMessage(
                 content="There is no pending plan submission right now.",
@@ -6763,21 +6836,52 @@ class TimeboxingFlowAgent(RoutedAgent):
                 session,
                 "submission_skipped",
                 reason="missing_tb_plan",
+                submit_mode=submit_mode,
+                submit_attempt_kind=submit_attempt_kind,
             )
-            return TextMessage(
-                content="Cannot submit yet because the plan is incomplete. Please refine first.",
-                source=self._agent_source(),
-            )
+            return self._build_submit_incomplete_reply()
         if session.base_snapshot is None:
             session.pending_submit = False
             self._session_debug(
                 session,
                 "submission_skipped",
                 reason="missing_base_snapshot",
+                submit_mode=submit_mode,
+                submit_attempt_kind=submit_attempt_kind,
             )
-            return TextMessage(
-                content="Cannot submit yet because the plan is incomplete. Please refine first.",
-                source=self._agent_source(),
+            return self._build_submit_incomplete_reply()
+
+        preview_ops = []
+        if submit_attempt_kind == "resubmit":
+            preview_ops = plan_sync(
+                session.base_snapshot,
+                session.tb_plan,
+                session.event_id_map,
+                remote_event_ids_by_index=session.remote_event_ids_by_index,
+            )
+        if submit_attempt_kind == "resubmit" and not preview_ops:
+            session.pending_submit = False
+            session.committed = True
+            self._session_debug(
+                session,
+                "submission_result",
+                status="committed",
+                changed=False,
+                created=0,
+                updated=0,
+                deleted=0,
+                failed=0,
+                failed_ops=[],
+                ops=0,
+                elapsed_s=0.0,
+                submit_mode=submit_mode,
+                submit_attempt_kind=submit_attempt_kind,
+                no_material_delta=True,
+            )
+            text = "Calendar already up to date. No changes were needed."
+            return SlackBlockMessage(
+                text=text,
+                blocks=[build_markdown_block(text=text)],
             )
 
         submit_started_at = perf_counter()
@@ -6786,6 +6890,8 @@ class TimeboxingFlowAgent(RoutedAgent):
             "submission_start",
             remote_events=len(session.base_snapshot.events),
             event_id_map_size=len(session.event_id_map),
+            submit_mode=submit_mode,
+            submit_attempt_kind=submit_attempt_kind,
         )
         previous_map = dict(session.event_id_map)
         try:
@@ -6803,6 +6909,8 @@ class TimeboxingFlowAgent(RoutedAgent):
                 error_type=type(exc).__name__,
                 error=str(exc)[:2000],
                 elapsed_s=round(perf_counter() - submit_started_at, 3),
+                submit_mode=submit_mode,
+                submit_attempt_kind=submit_attempt_kind,
             )
             return TextMessage(
                 content="Calendar submission failed. Please try again.",
@@ -6831,6 +6939,9 @@ class TimeboxingFlowAgent(RoutedAgent):
             failed_ops=summary.failed_details[:3],
             ops=len(tx.ops),
             elapsed_s=round(perf_counter() - submit_started_at, 3),
+            submit_mode=submit_mode,
+            submit_attempt_kind=submit_attempt_kind,
+            no_material_delta=False,
         )
 
         if tx.status == "committed":

--- a/src/fateforger/agents/timeboxing/stage_gating.py
+++ b/src/fateforger/agents/timeboxing/stage_gating.py
@@ -75,6 +75,7 @@ class StageDecision(BaseModel):
     action: StageAction
     target_stage: Optional[TimeboxingStage] = None
     note: Optional[str] = None
+    submit_intent: bool = False
     assist_target: Optional[str] = None
     assist_confidence: Optional[float] = Field(default=None, ge=0.0, le=1.0)
 
@@ -255,6 +256,9 @@ Decision rules
 - If the user asks to redo the current stage, use action="redo".
 - If the user wants to stop, use action="cancel".
 - If the user asks an adjacent question that clearly requires another specialist, use action="assist".
+- If the user explicitly asks to commit/submit/add the schedule to calendar now, set `submit_intent=true`.
+- Set `submit_intent=false` when explicit commit/submit intent is absent.
+- `submit_intent` can be true with any in-flow action when the user wants commit after edits (for example action="provide_info" + commit request).
 - For action="assist", you must also set:
   - `assist_target`: the specialist to route to (currently only `"tasks_agent"` is available from this flow)
   - `assist_confidence`: confidence 0.0-1.0 that handoff is the right route

--- a/tests/unit/test_timeboxing_session_init_order.py
+++ b/tests/unit/test_timeboxing_session_init_order.py
@@ -300,10 +300,10 @@ async def test_on_user_reply_review_commit_proceed_submits_without_button() -> N
 
     async def _decide_next_action(session_obj: Session, *, user_message: str):  # noqa: ARG001
         _ = session_obj
-        return StageDecision(action="proceed")
+        return StageDecision(action="proceed", submit_intent=True)
 
-    async def _submit_pending_plan(*, session: Session):
-        _ = session
+    async def _submit_pending_plan(*, session: Session, submit_mode: str, submit_attempt_kind: str):  # noqa: ARG001
+        _ = session, submit_mode, submit_attempt_kind
         calls["submit"] += 1
         return TextMessage(content="submitted-from-nl", source="timeboxing_agent")
 
@@ -331,6 +331,243 @@ async def test_on_user_reply_review_commit_proceed_submits_without_button() -> N
     assert out.content == "submitted-from-nl"
     assert calls["submit"] == 1
     assert calls["run_graph"] == 0
+
+
+@pytest.mark.asyncio
+async def test_on_user_reply_refine_explicit_commit_submits_in_same_turn() -> None:
+    agent = _build_agent()
+    session = Session(
+        thread_ts="thread-refine-submit",
+        channel_id="C1",
+        user_id="U1",
+        committed=True,
+        planned_date="2026-02-27",
+        tz_name="UTC",
+        session_key="thread-refine-submit",
+    )
+    session.stage = TimeboxingStage.REFINE
+    session.tb_plan = object()  # type: ignore[assignment]
+    session.base_snapshot = object()  # type: ignore[assignment]
+    agent._sessions["thread-refine-submit"] = session
+    calls = {"submit": 0, "run_graph": 0}
+
+    async def _decide_next_action(session_obj: Session, *, user_message: str):  # noqa: ARG001
+        _ = session_obj
+        return StageDecision(action="provide_info", submit_intent=True)
+
+    async def _submit_pending_plan(*, session: Session, submit_mode: str, submit_attempt_kind: str):  # noqa: ARG001
+        _ = submit_mode, submit_attempt_kind
+        calls["submit"] += 1
+        return TextMessage(content="submitted-from-refine", source="timeboxing_agent")
+
+    async def _run_graph_turn(*, session: Session, user_text: str):  # noqa: ARG001
+        _ = session, user_text
+        calls["run_graph"] += 1
+        return TextMessage(content="graph-progressed", source="timeboxing_agent")
+
+    def _attach_presenter_blocks(*, reply: TextMessage, session: Session):
+        _ = reply
+        session.stage = TimeboxingStage.REVIEW_COMMIT
+        session.pending_submit = True
+        session.tb_plan = object()  # type: ignore[assignment]
+        session.base_snapshot = object()  # type: ignore[assignment]
+        return TextMessage(content="review-ready", source="timeboxing_agent")
+
+    agent._decide_next_action = _decide_next_action
+    agent._submit_pending_plan = _submit_pending_plan
+    agent._run_graph_turn = _run_graph_turn
+    agent._attach_presenter_blocks = _attach_presenter_blocks
+
+    out = await TimeboxingFlowAgent.on_user_reply(
+        agent,
+        TimeboxingUserReply(
+            channel_id="C1",
+            thread_ts="thread-refine-submit",
+            user_id="U1",
+            text="apply those edits and commit to calendar now",
+        ),
+        SimpleNamespace(),
+    )
+
+    assert isinstance(out, TextMessage)
+    assert out.content == "submitted-from-refine"
+    assert calls["submit"] == 1
+    assert calls["run_graph"] == 1
+
+
+@pytest.mark.asyncio
+async def test_on_user_reply_review_commit_explicit_commit_submits_after_review_render() -> None:
+    agent = _build_agent()
+    session = Session(
+        thread_ts="thread-review-submit",
+        channel_id="C1",
+        user_id="U1",
+        committed=True,
+        planned_date="2026-02-27",
+        tz_name="UTC",
+        session_key="thread-review-submit",
+    )
+    session.stage = TimeboxingStage.REVIEW_COMMIT
+    session.pending_submit = False
+    session.tb_plan = object()  # type: ignore[assignment]
+    session.base_snapshot = object()  # type: ignore[assignment]
+    agent._sessions["thread-review-submit"] = session
+    calls = {"submit": 0, "run_graph": 0}
+
+    async def _decide_next_action(session_obj: Session, *, user_message: str):  # noqa: ARG001
+        _ = session_obj
+        return StageDecision(action="proceed", submit_intent=True)
+
+    async def _submit_pending_plan(*, session: Session, submit_mode: str, submit_attempt_kind: str):  # noqa: ARG001
+        _ = submit_mode, submit_attempt_kind
+        calls["submit"] += 1
+        return TextMessage(content="submitted-after-review", source="timeboxing_agent")
+
+    async def _run_graph_turn(*, session: Session, user_text: str):  # noqa: ARG001
+        _ = session, user_text
+        calls["run_graph"] += 1
+        return TextMessage(content="review-progressed", source="timeboxing_agent")
+
+    def _attach_presenter_blocks(*, reply: TextMessage, session: Session):
+        _ = reply
+        session.pending_submit = True
+        session.tb_plan = object()  # type: ignore[assignment]
+        session.base_snapshot = object()  # type: ignore[assignment]
+        return TextMessage(content="review-ready", source="timeboxing_agent")
+
+    agent._decide_next_action = _decide_next_action
+    agent._submit_pending_plan = _submit_pending_plan
+    agent._run_graph_turn = _run_graph_turn
+    agent._attach_presenter_blocks = _attach_presenter_blocks
+
+    out = await TimeboxingFlowAgent.on_user_reply(
+        agent,
+        TimeboxingUserReply(
+            channel_id="C1",
+            thread_ts="thread-review-submit",
+            user_id="U1",
+            text="yes commit it now",
+        ),
+        SimpleNamespace(),
+    )
+
+    assert isinstance(out, TextMessage)
+    assert out.content == "submitted-after-review"
+    assert calls["submit"] == 1
+    assert calls["run_graph"] == 1
+
+
+@pytest.mark.asyncio
+async def test_on_user_reply_review_commit_without_explicit_submit_intent_does_not_submit() -> None:
+    agent = _build_agent()
+    session = Session(
+        thread_ts="thread-review-no-submit",
+        channel_id="C1",
+        user_id="U1",
+        committed=True,
+        planned_date="2026-02-27",
+        tz_name="UTC",
+        session_key="thread-review-no-submit",
+    )
+    session.stage = TimeboxingStage.REVIEW_COMMIT
+    session.pending_submit = True
+    agent._sessions["thread-review-no-submit"] = session
+    calls = {"submit": 0, "run_graph": 0}
+
+    async def _decide_next_action(session_obj: Session, *, user_message: str):  # noqa: ARG001
+        _ = session_obj
+        return StageDecision(action="proceed", submit_intent=False)
+
+    async def _submit_pending_plan(*, session: Session, submit_mode: str, submit_attempt_kind: str):  # noqa: ARG001
+        _ = session, submit_mode, submit_attempt_kind
+        calls["submit"] += 1
+        return TextMessage(content="submitted", source="timeboxing_agent")
+
+    async def _run_graph_turn(*, session: Session, user_text: str):  # noqa: ARG001
+        _ = session, user_text
+        calls["run_graph"] += 1
+        return TextMessage(content="graph-progressed", source="timeboxing_agent")
+
+    agent._decide_next_action = _decide_next_action
+    agent._submit_pending_plan = _submit_pending_plan
+    agent._run_graph_turn = _run_graph_turn
+
+    out = await TimeboxingFlowAgent.on_user_reply(
+        agent,
+        TimeboxingUserReply(
+            channel_id="C1",
+            thread_ts="thread-review-no-submit",
+            user_id="U1",
+            text="looks good, proceed",
+        ),
+        SimpleNamespace(),
+    )
+
+    assert isinstance(out, TextMessage)
+    assert out.content == "graph-progressed"
+    assert calls["submit"] == 0
+    assert calls["run_graph"] == 1
+
+
+@pytest.mark.asyncio
+async def test_on_user_reply_explicit_commit_when_prereqs_missing_returns_actionable_non_submit() -> None:
+    agent = _build_agent()
+    session = Session(
+        thread_ts="thread-review-missing-prereqs",
+        channel_id="C1",
+        user_id="U1",
+        committed=True,
+        planned_date="2026-02-27",
+        tz_name="UTC",
+        session_key="thread-review-missing-prereqs",
+    )
+    session.stage = TimeboxingStage.REVIEW_COMMIT
+    session.pending_submit = False
+    session.tb_plan = None
+    session.base_snapshot = None
+    agent._sessions["thread-review-missing-prereqs"] = session
+    calls = {"submit": 0}
+
+    async def _decide_next_action(session_obj: Session, *, user_message: str):  # noqa: ARG001
+        _ = session_obj
+        return StageDecision(action="proceed", submit_intent=True)
+
+    async def _run_graph_turn(*, session: Session, user_text: str):  # noqa: ARG001
+        _ = session, user_text
+        return TextMessage(content="review-stage", source="timeboxing_agent")
+
+    def _attach_presenter_blocks(*, reply: TextMessage, session: Session):
+        _ = reply
+        session.stage = TimeboxingStage.REVIEW_COMMIT
+        session.pending_submit = False
+        session.tb_plan = None
+        session.base_snapshot = None
+        return TextMessage(content="still-missing", source="timeboxing_agent")
+
+    async def _submit_pending_plan(*, session: Session, submit_mode: str, submit_attempt_kind: str):  # noqa: ARG001
+        _ = session, submit_mode, submit_attempt_kind
+        calls["submit"] += 1
+        return TextMessage(content="submitted", source="timeboxing_agent")
+
+    agent._decide_next_action = _decide_next_action
+    agent._run_graph_turn = _run_graph_turn
+    agent._attach_presenter_blocks = _attach_presenter_blocks
+    agent._submit_pending_plan = _submit_pending_plan
+
+    out = await TimeboxingFlowAgent.on_user_reply(
+        agent,
+        TimeboxingUserReply(
+            channel_id="C1",
+            thread_ts="thread-review-missing-prereqs",
+            user_id="U1",
+            text="commit to calendar now",
+        ),
+        SimpleNamespace(),
+    )
+
+    assert isinstance(out, TextMessage)
+    assert "Cannot submit yet because the plan is incomplete." in out.content
+    assert calls["submit"] == 0
 
 
 @pytest.mark.asyncio

--- a/tests/unit/test_timeboxing_submit_flow.py
+++ b/tests/unit/test_timeboxing_submit_flow.py
@@ -308,3 +308,42 @@ async def test_refine_patch_path_stages_locally_without_remote_submit() -> None:
     assert session.timebox is not None
     assert session.timebox.events[0].summary == "Patched Focus"
     agent._submit_current_plan.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_submit_pending_plan_resubmit_no_delta_returns_noop_success() -> None:
+    """Re-submit with no material delta should succeed as explicit no-op."""
+    submit_plan = AsyncMock(return_value=_build_submit_transaction())
+    agent = TimeboxingFlowAgent.__new__(TimeboxingFlowAgent)
+    agent._calendar_submitter = SimpleNamespace(submit_plan=submit_plan)
+    debug_events: list[tuple[str, dict]] = []
+    agent._session_debug = (
+        lambda _session, event, **kwargs: debug_events.append((event, kwargs))
+    )
+
+    session = Session(thread_ts="t1", channel_id="c1", user_id="u1")
+    session.tz_name = "Europe/Amsterdam"
+    session.stage = TimeboxingStage.REVIEW_COMMIT
+    session.pending_submit = True
+    session.tb_plan = _build_plan(summary="Noop")
+    session.base_snapshot = _build_plan(summary="Noop")
+    session.event_id_map = {}
+    session.remote_event_ids_by_index = []
+    session.last_sync_transaction = _build_submit_transaction()
+
+    result = await TimeboxingFlowAgent._submit_pending_plan(
+        agent,
+        session=session,
+        submit_mode="auto_nl",
+        submit_attempt_kind="resubmit",
+    )
+
+    assert isinstance(result, SlackBlockMessage)
+    assert "already up to date" in result.text
+    assert session.pending_submit is False
+    submit_plan.assert_not_awaited()
+    result_events = [payload for name, payload in debug_events if name == "submission_result"]
+    assert result_events
+    assert result_events[-1]["submit_mode"] == "auto_nl"
+    assert result_events[-1]["submit_attempt_kind"] == "resubmit"
+    assert result_events[-1]["no_material_delta"] is True


### PR DESCRIPTION
## Summary
- add typed `submit_intent` to StageDecision so commit intent is classified by the stage-decision LLM
- enable same-turn auto-submit for explicit commit intent in both Refine and ReviewCommit paths when submission prerequisites are ready
- return deterministic actionable response when explicit commit is requested but plan/baseline prerequisites are missing
- add submit telemetry fields to session debug events: `submit_mode` (`auto_nl`/`manual_button`) and `submit_attempt_kind` (`first_submit`/`resubmit`)
- add idempotent resubmit guard: on `resubmit`, if no material delta vs remote baseline, return explicit no-op success and skip remote submit call

## Tests
- `tests/unit/test_timeboxing_session_init_order.py`
- `tests/unit/test_timeboxing_submit_flow.py`
- `tests/unit/test_timeboxing_stage_actions.py`
- `tests/unit/test_timeboxing_review_submit_prompt.py`

Fixes #71
