### PR TITLE
fix(timeboxing): prevent post-patch refine timeouts with budget-aware fast path

### DIFF
--- a/src/fateforger/agents/timeboxing/agent.py
+++ b/src/fateforger/agents/timeboxing/agent.py
@@ -342,6 +342,8 @@ class Session:
     thread_state: str | None = None
     session_key: str | None = None
     debug_log_path: str | None = None
+    graph_turn_started_at_monotonic: float | None = None
+    graph_turn_deadline_monotonic: float | None = None
 
 
 @dataclass
@@ -712,6 +714,10 @@ class TimeboxingFlowAgent(RoutedAgent):
         async with session.graph_turn_lock:
             turn_started_at = perf_counter()
             turn_elapsed_s = lambda: round(perf_counter() - turn_started_at, 3)
+            session.graph_turn_started_at_monotonic = turn_started_at
+            session.graph_turn_deadline_monotonic = (
+                turn_started_at + TIMEBOXING_TIMEOUTS.graph_turn_s
+            )
             self._refresh_temporal_facts(session)
             self._session_debug(
                 session,
@@ -731,69 +737,73 @@ class TimeboxingFlowAgent(RoutedAgent):
                 return presenter_message
 
             try:
-                presenter = await with_timeout(
-                    "timeboxing:graph-turn",
-                    _run_stream(),
-                    timeout_s=TIMEBOXING_TIMEOUTS.graph_turn_s,
-                    dump_on_timeout=False,
-                    dump_threads_on_timeout=False,
+                try:
+                    presenter = await with_timeout(
+                        "timeboxing:graph-turn",
+                        _run_stream(),
+                        timeout_s=TIMEBOXING_TIMEOUTS.graph_turn_s,
+                        dump_on_timeout=False,
+                        dump_threads_on_timeout=False,
+                    )
+                except TimeoutError as exc:
+                    timeout_message = "This turn hit a processing timeout. Reply `Redo` to retry this stage."
+                    self._session_debug(
+                        session,
+                        "graph_turn_timeout",
+                        error_type=type(exc).__name__,
+                        timeout_s=TIMEBOXING_TIMEOUTS.graph_turn_s,
+                        elapsed_s=turn_elapsed_s(),
+                    )
+                    self._session_debug(
+                        session,
+                        "graph_turn_end",
+                        presenter_found=False,
+                        output_preview=timeout_message[:500],
+                        elapsed_s=turn_elapsed_s(),
+                    )
+                    observe_stage_duration(
+                        stage=session.stage.value if session.stage else "unknown",
+                        duration_s=turn_elapsed_s(),
+                    )
+                    return TextMessage(content=timeout_message, source=self.id.type)
+                except Exception as exc:
+                    self._session_debug(
+                        session,
+                        "graph_turn_error",
+                        error_type=type(exc).__name__,
+                        error=str(exc)[:2000],
+                        elapsed_s=turn_elapsed_s(),
+                    )
+                    raise
+                content = (
+                    presenter.content
+                    if presenter
+                    else "No stage response was generated. Reply `Redo` to retry this stage."
                 )
-            except TimeoutError as exc:
-                timeout_message = "This turn hit a processing timeout. Reply `Redo` to retry this stage."
-                self._session_debug(
-                    session,
-                    "graph_turn_timeout",
-                    error_type=type(exc).__name__,
-                    timeout_s=TIMEBOXING_TIMEOUTS.graph_turn_s,
-                    elapsed_s=turn_elapsed_s(),
-                )
+                elapsed_s = turn_elapsed_s()
                 self._session_debug(
                     session,
                     "graph_turn_end",
-                    presenter_found=False,
-                    output_preview=timeout_message[:500],
-                    elapsed_s=turn_elapsed_s(),
+                    presenter_found=presenter is not None,
+                    output_preview=content[:500],
+                    elapsed_s=elapsed_s,
                 )
                 observe_stage_duration(
                     stage=session.stage.value if session.stage else "unknown",
-                    duration_s=turn_elapsed_s(),
+                    duration_s=elapsed_s,
                 )
-                return TextMessage(content=timeout_message, source=self.id.type)
-            except Exception as exc:
-                self._session_debug(
-                    session,
-                    "graph_turn_error",
-                    error_type=type(exc).__name__,
-                    error=str(exc)[:2000],
-                    elapsed_s=turn_elapsed_s(),
-                )
-                raise
-            content = (
-                presenter.content
-                if presenter
-                else "No stage response was generated. Reply `Redo` to retry this stage."
-            )
-            elapsed_s = turn_elapsed_s()
-            self._session_debug(
-                session,
-                "graph_turn_end",
-                presenter_found=presenter is not None,
-                output_preview=content[:500],
-                elapsed_s=elapsed_s,
-            )
-            observe_stage_duration(
-                stage=session.stage.value if session.stage else "unknown",
-                duration_s=elapsed_s,
-            )
-            if elapsed_s >= TIMEBOXING_TIMEOUTS.slow_turn_warn_s:
-                self._session_debug(
-                    session,
-                    "graph_turn_slow",
-                    elapsed_s=elapsed_s,
-                    threshold_s=TIMEBOXING_TIMEOUTS.slow_turn_warn_s,
-                    user_text_preview=(user_text or "")[:200],
-                )
-            return TextMessage(content=content, source=self.id.type)
+                if elapsed_s >= TIMEBOXING_TIMEOUTS.slow_turn_warn_s:
+                    self._session_debug(
+                        session,
+                        "graph_turn_slow",
+                        elapsed_s=elapsed_s,
+                        threshold_s=TIMEBOXING_TIMEOUTS.slow_turn_warn_s,
+                        user_text_preview=(user_text or "")[:200],
+                    )
+                return TextMessage(content=content, source=self.id.type)
+            finally:
+                session.graph_turn_started_at_monotonic = None
+                session.graph_turn_deadline_monotonic = None
 
     # TODO: this should be build into the agent itself using the autogen message in that stage, not bolted on like this
     async def _interpret_planned_date(
@@ -3151,6 +3161,39 @@ class TimeboxingFlowAgent(RoutedAgent):
             payload["next_suggestion"] = session.last_quality_next_step
         return payload
 
+    @staticmethod
+    def _remaining_graph_turn_budget_s(session: Session) -> float | None:
+        """Return remaining graph-turn budget in seconds for the current turn."""
+        deadline = session.graph_turn_deadline_monotonic
+        if deadline is None:
+            return None
+        return max(0.0, deadline - perf_counter())
+
+    def _build_refine_budget_fastpath_gate(
+        self, *, session: Session
+    ) -> StageGateOutput:
+        """Build a deterministic refine gate when turn budget is nearly exhausted."""
+        summary = [
+            "Patch applied locally and staged for review.",
+            "Skipping extra quality analysis this turn to avoid a timeout.",
+        ]
+        snapshot = self._quality_snapshot_for_prompt(session)
+        if snapshot:
+            level = snapshot.get("quality_level")
+            label = snapshot.get("quality_label")
+            if isinstance(level, int) and isinstance(label, str) and label.strip():
+                summary.append(f"Last known quality: {label.strip()} ({level}/4).")
+        return StageGateOutput(
+            stage_id=TimeboxingStage.REFINE,
+            ready=True,
+            summary=summary,
+            missing=[],
+            question=(
+                "Reply with edits, or say `commit now` to submit this staged patch to calendar."
+            ),
+            facts=snapshot,
+        )
+
     async def _run_refine_quality_assessment(
         self, *, timebox: Timebox
     ) -> RefineQualityFacts:
@@ -3222,6 +3265,7 @@ class TimeboxingFlowAgent(RoutedAgent):
         stage: TimeboxingStage,
         timebox: Timebox,
         session: Session | None = None,
+        allow_quality_enrichment: bool = True,
     ) -> StageGateOutput:
         """Generate a summary for a timebox draft.
 
@@ -3249,12 +3293,20 @@ class TimeboxingFlowAgent(RoutedAgent):
             timeout_s=TIMEBOXING_TIMEOUTS.summary_s,
         )
         gate = parse_chat_content(StageGateOutput, response)
-        if stage == TimeboxingStage.REFINE and session is not None:
+        if (
+            stage == TimeboxingStage.REFINE
+            and session is not None
+            and allow_quality_enrichment
+        ):
             gate = await self._enrich_refine_quality_feedback(
                 session=session,
                 gate=gate,
                 timebox=timebox,
             )
+        elif stage == TimeboxingStage.REFINE and session is not None:
+            snapshot = self._quality_snapshot_for_prompt(session)
+            if snapshot:
+                gate.facts = {**snapshot, **(gate.facts or {})}
         return gate
 
     async def _run_review_commit(self, *, timebox: Timebox) -> StageGateOutput:

--- a/src/fateforger/agents/timeboxing/constants.py
+++ b/src/fateforger/agents/timeboxing/constants.py
@@ -34,6 +34,8 @@ class TimeboxingTimeouts:
     tasks_snapshot_s: float = 12.0
     graph_turn_s: float = 120.0
     slow_turn_warn_s: float = 30.0
+    refine_summary_min_budget_s: float = 25.0
+    refine_quality_min_budget_s: float = 45.0
 
 
 @dataclass(frozen=True, slots=True)

--- a/src/fateforger/agents/timeboxing/nodes/nodes.py
+++ b/src/fateforger/agents/timeboxing/nodes/nodes.py
@@ -25,6 +25,7 @@ from fateforger.agents.shared.handoff_policy import (
     HandoffPolicy,
     HandoffRoute,
 )
+from fateforger.agents.timeboxing.constants import TIMEBOXING_TIMEOUTS
 from fateforger.agents.timeboxing.stage_gating import (
     StageDecision,
     StageGateOutput,
@@ -641,11 +642,40 @@ class StageRefineNode(_StageNodeBase):
             self._session.stage_question = gate.question
             self.last_gate = gate
             return Response(chat_message=StructuredMessage(source=self.name, content=gate))
-        gate = await self._orchestrator._run_timebox_summary(  # noqa: SLF001
-            stage=TimeboxingStage.REFINE,
-            timebox=self._session.timebox,
-            session=self._session,
+        remaining_budget_s = self._orchestrator._remaining_graph_turn_budget_s(  # noqa: SLF001
+            self._session
         )
+        if (
+            remaining_budget_s is not None
+            and remaining_budget_s < TIMEBOXING_TIMEOUTS.refine_summary_min_budget_s
+        ):
+            self._orchestrator._session_debug(  # noqa: SLF001
+                self._session,
+                "refine_summary_fastpath",
+                remaining_budget_s=round(remaining_budget_s, 3),
+                threshold_s=TIMEBOXING_TIMEOUTS.refine_summary_min_budget_s,
+            )
+            gate = self._orchestrator._build_refine_budget_fastpath_gate(  # noqa: SLF001
+                session=self._session
+            )
+        else:
+            allow_quality = (
+                remaining_budget_s is None
+                or remaining_budget_s >= TIMEBOXING_TIMEOUTS.refine_quality_min_budget_s
+            )
+            if not allow_quality:
+                self._orchestrator._session_debug(  # noqa: SLF001
+                    self._session,
+                    "refine_quality_skipped_budget",
+                    remaining_budget_s=round(remaining_budget_s or 0.0, 3),
+                    threshold_s=TIMEBOXING_TIMEOUTS.refine_quality_min_budget_s,
+                )
+            gate = await self._orchestrator._run_timebox_summary(  # noqa: SLF001
+                stage=TimeboxingStage.REFINE,
+                timebox=self._session.timebox,
+                session=self._session,
+                allow_quality_enrichment=allow_quality,
+            )
         if execution.calendar.note:
             gate.summary.append(execution.calendar.note)
         if execution.fallback_patch_used:

--- a/tests/unit/test_phase4_rewiring.py
+++ b/tests/unit/test_phase4_rewiring.py
@@ -299,8 +299,10 @@ class TestRefineNodeUsesTBPlan:
             session.base_snapshot = seed_plan.model_copy(deep=True)
             return RefinePreflight()
 
-        async def _run_summary(*, stage, timebox, session=None) -> StageGateOutput:
-            _ = (timebox, session)
+        async def _run_summary(
+            *, stage, timebox, session=None, allow_quality_enrichment=True
+        ) -> StageGateOutput:
+            _ = (timebox, session, allow_quality_enrichment)
             return StageGateOutput(
                 stage_id=stage,
                 ready=True,
@@ -423,8 +425,10 @@ class TestRefineNodeUsesTBPlan:
                 ]
             )
 
-        async def _run_summary(*, stage, timebox, session=None) -> StageGateOutput:
-            _ = (timebox, session)
+        async def _run_summary(
+            *, stage, timebox, session=None, allow_quality_enrichment=True
+        ) -> StageGateOutput:
+            _ = (timebox, session, allow_quality_enrichment)
             return StageGateOutput(
                 stage_id=stage,
                 ready=True,
@@ -528,8 +532,10 @@ class TestRefineNodeUsesTBPlan:
 
         agent = TimeboxingFlowAgent.__new__(TimeboxingFlowAgent)
 
-        async def _run_summary(*, stage, timebox, session=None) -> StageGateOutput:
-            _ = (timebox, session)
+        async def _run_summary(
+            *, stage, timebox, session=None, allow_quality_enrichment=True
+        ) -> StageGateOutput:
+            _ = (timebox, session, allow_quality_enrichment)
             return StageGateOutput(
                 stage_id=stage,
                 ready=True,
@@ -608,6 +614,120 @@ class TestRefineNodeUsesTBPlan:
 
         assert node.last_gate is not None
         assert "Calendar changed: 1 created, 0 updated, 0 deleted." in node.last_gate.summary
+
+    @pytest.mark.asyncio
+    async def test_refine_node_uses_budget_fastpath_when_turn_budget_low(self) -> None:
+        """Refine should skip LLM summary/quality when remaining turn budget is too low."""
+        from autogen_agentchat.messages import TextMessage
+        from autogen_core import CancellationToken
+
+        from fateforger.agents.timeboxing.nodes.nodes import StageRefineNode, TransitionNode
+
+        agent = TimeboxingFlowAgent.__new__(TimeboxingFlowAgent)
+        session = Session(
+            thread_ts="t1",
+            channel_id="c1",
+            user_id="u1",
+            stage=TimeboxingStage.REFINE,
+        )
+        session.timebox = Timebox(
+            events=[
+                CalendarEvent(
+                    summary="Focus",
+                    event_type=EventType.DEEP_WORK,
+                    start_time=time(9, 0),
+                    duration=timedelta(minutes=90),
+                )
+            ],
+            date=date(2026, 2, 13),
+            timezone="Europe/Amsterdam",
+        )
+        session.tb_plan = timebox_to_tb_plan(session.timebox)
+        session.base_snapshot = session.tb_plan.model_copy(deep=True)
+
+        def _ensure_refine(_self, _session: Session) -> RefinePreflight:
+            return RefinePreflight()
+
+        async def _run_orchestration(
+            *,
+            session: Session,
+            patch_message: str,
+            user_message: str,
+        ) -> RefineToolExecutionOutcome:
+            _ = (patch_message, user_message)
+            return RefineToolExecutionOutcome(
+                patch_selected=True,
+                memory_selected=False,
+                memory_queued=False,
+                fallback_patch_used=False,
+                calendar=CalendarSyncOutcome(
+                    status="staged",
+                    changed=True,
+                    note="Plan updated locally. Review Stage 5 and click Submit to sync to calendar.",
+                ),
+            )
+
+        def _fastpath_gate(_self, *, session: Session) -> StageGateOutput:
+            _ = session
+            return StageGateOutput(
+                stage_id=TimeboxingStage.REFINE,
+                ready=True,
+                summary=["Patch applied locally and staged for review."],
+                missing=[],
+                question="Reply with edits, or say `commit now`.",
+                facts={},
+            )
+
+        agent._ensure_calendar_immovables = types.MethodType(  # type: ignore[attr-defined]
+            lambda self, session: asyncio.sleep(0),
+            agent,
+        )
+        agent._ensure_refine_plan_state = types.MethodType(  # type: ignore[attr-defined]
+            _ensure_refine,
+            agent,
+        )
+        agent._compose_patcher_message = types.MethodType(  # type: ignore[attr-defined]
+            lambda self, **kwargs: kwargs["base_message"],
+            agent,
+        )
+        agent._run_refine_tool_orchestration = types.MethodType(  # type: ignore[attr-defined]
+            lambda self, **kwargs: _run_orchestration(**kwargs),
+            agent,
+        )
+        agent._remaining_graph_turn_budget_s = types.MethodType(  # type: ignore[attr-defined]
+            lambda self, _session: 5.0,
+            agent,
+        )
+        agent._build_refine_budget_fastpath_gate = types.MethodType(  # type: ignore[attr-defined]
+            _fastpath_gate,
+            agent,
+        )
+        agent._session_debug = types.MethodType(  # type: ignore[attr-defined]
+            lambda self, *_args, **_kwargs: None,
+            agent,
+        )
+        agent._run_timebox_summary = AsyncMock()  # type: ignore[attr-defined]
+
+        transition = TransitionNode.__new__(TransitionNode)
+        transition.stage_user_message = "tighten deep work blocks"
+        transition.decision = None
+
+        node = StageRefineNode(
+            orchestrator=agent,
+            session=session,
+            transition=transition,
+        )
+
+        await node.on_messages(
+            [TextMessage(content="tighten deep work blocks", source="user")],
+            CancellationToken(),
+        )
+
+        agent._run_timebox_summary.assert_not_awaited()  # type: ignore[attr-defined]
+        assert node.last_gate is not None
+        assert node.last_gate.ready is True
+        assert "Patch applied locally" in node.last_gate.summary[0]
+        assert any("Plan updated locally" in line for line in node.last_gate.summary)
 
 
 class TestRefineQualityFacts:

--- a/tests/unit/test_timeboxing_graph_turn_lock.py
+++ b/tests/unit/test_timeboxing_graph_turn_lock.py
@@ -63,6 +63,8 @@ async def test_run_graph_turn_serializes_concurrent_calls_per_session() -> None:
     assert isinstance(out_b, TextMessage)
     assert flow.calls == 2
     assert flow.max_running == 1
+    assert session.graph_turn_started_at_monotonic is None
+    assert session.graph_turn_deadline_monotonic is None
 
 
 @pytest.mark.asyncio
@@ -110,3 +112,5 @@ async def test_run_graph_turn_returns_timeout_message_when_outer_timeout_hits(
     assert "processing timeout" in out.content
     assert events.count("graph_turn_timeout") == 1
     assert events.count("graph_turn_end") == 1
+    assert session.graph_turn_started_at_monotonic is None
+    assert session.graph_turn_deadline_monotonic is None


### PR DESCRIPTION
## Summary
This PR fixes the Stage 4 failure mode where patching succeeds but the same turn times out before presenter output.

### What changed
- Added per-turn budget tracking on `Session` (`graph_turn_started_at_monotonic`, `graph_turn_deadline_monotonic`).
- Added budget-aware Refine behavior in `StageRefineNode`:
  - if remaining turn budget is below threshold, use deterministic fast-path gate instead of extra LLM summary pass.
  - if budget is moderate, allow summary but skip extra quality-enrichment LLM call.
- Added deterministic refine fast-path gate builder in `TimeboxingFlowAgent`.
- Ensured graph-turn budget metadata is always cleared via `finally`.
- Added timeout thresholds in `TimeboxingTimeouts`:
  - `refine_summary_min_budget_s`
  - `refine_quality_min_budget_s`

## Tests
- `poetry run pytest tests/unit/test_phase4_rewiring.py tests/unit/test_timeboxing_graph_turn_lock.py -q`
- `poetry run pytest tests/unit/test_timeboxing_submit_flow.py tests/unit/test_timeboxing_stage_actions.py tests/unit/test_timeboxing_refine_tool_orchestration.py -q`

All passing.

## Linked issue
Closes #72
