### PR TITLE
fix(planning): close #87 with strict verification + reminder replay hardening

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -12,6 +12,15 @@
 - Avoid editing generated/artifact outputs and local state (e.g. `site/`, `*.db`, `logs/`, token/secret folders) unless explicitly requested.
 - Ask before adding dependencies or changing schemas/DB models; deliver schema changes via Alembic migrations (no runtime “ensure_*” table/column creation in live paths).
 
+## Cross-cutting proposal contract (critical)
+- For Slack-delivered proposed objects (event/task/constraint/etc.), enforce one reusable interaction pattern:
+  - proposal object is typed,
+  - user response is interpreted as typed intent (+ optional typed patch/update),
+  - NL reply and UI action converge to the same submit executor.
+- Never add deterministic free-form NLU (regex/substring/keyword) for proposal intent extraction.
+- Deterministic parsing is only allowed for structured transport fields (IDs, timestamps, encoded metadata).
+- Keep contract details in `docs/architecture/proposal_object_contract.md` and ensure module `AGENTS.md` files reference/apply it where relevant.
+
 ## Git write authority (critical)
 - The agent must not run `git commit` or `git push` unless the user explicitly asks for it in the current turn.
 - Default behavior: implement changes, run validation, and stop at a review-ready working tree.
@@ -215,6 +224,10 @@ poetry run python scripts/dev/timebox_log_query.py llm --log-path logs/llm_io_20
 
 ## Slack capability audit loop (critical)
 - Use the Slack skill as the primary operator surface for live end-to-end audits of agent behavior in Slack.
+- Restart the local Slack bot runtime before each manual audit replay so validation reflects the latest code and avoids stale in-memory state.
+- After restart, verify runtime prerequisites before sending audit prompts:
+  - required MCP dependencies are reachable (especially `calendar-mcp`),
+  - Prometheus scrape is healthy (`up{job="fateforger_app"} == 1`).
 - For audits that require sending user-facing Slack messages, use Slack MCP (`agent-slack`) first; only use the fallback driver when MCP is unavailable or authentication fails.
 - If the Slack skill is unavailable, use the deterministic fallback driver (`scripts/dev/slack_user_timeboxing_driver.py`) with `SLACK_USER_TOKEN`.
 - Fallback driver thread identity rule:

--- a/src/fateforger/agents/schedular/agent.py
+++ b/src/fateforger/agents/schedular/agent.py
@@ -252,6 +252,15 @@ class PlannerAgent(HauntAwareAgentMixin, RoutedAgent):
                 return str(payload["error"])
         return None
 
+    @staticmethod
+    def _event_status(event: dict | None) -> str:
+        if not isinstance(event, dict):
+            return ""
+        status = str(event.get("status") or "").strip().lower()
+        if status == "canceled":
+            return "cancelled"
+        return status
+
     @classmethod
     def _event_matches_upsert_request(
         cls,
@@ -474,6 +483,7 @@ class PlannerAgent(HauntAwareAgentMixin, RoutedAgent):
         )
         workbench = self._ensure_workbench()
         tz = ZoneInfo(message.time_zone or "UTC")
+        preexisting_cancelled = False
 
         # Prefer deterministic upsert (get → update|create) over LLM tool-routing.
         exists = False
@@ -486,7 +496,30 @@ class PlannerAgent(HauntAwareAgentMixin, RoutedAgent):
                 },
             )
             event = self._normalize_event(self._extract_tool_payload(fetched))
-            exists = bool(event)
+            event_status = self._event_status(event)
+            if event_status == "cancelled":
+                preexisting_cancelled = True
+                logger.info(
+                    "Calendar pre-upsert event is cancelled; forcing recreate path: event_id=%s",
+                    message.event_id,
+                )
+                try:
+                    await workbench.call_tool(
+                        "delete-event",
+                        arguments={
+                            "calendarId": message.calendar_id,
+                            "eventId": message.event_id,
+                        },
+                    )
+                except Exception as exc:
+                    logger.warning(
+                        "Calendar pre-upsert delete-event failed for cancelled event; continuing with create path: event_id=%s error=%s",
+                        message.event_id,
+                        exc,
+                    )
+                exists = False
+            else:
+                exists = bool(event)
         except Exception as exc:
             logger.warning(
                 "Calendar pre-upsert get-event failed; assuming create path: event_id=%s error=%s",
@@ -502,57 +535,93 @@ class PlannerAgent(HauntAwareAgentMixin, RoutedAgent):
             normalized_end = self._calendar_event_datetime_arg(
                 message.end, time_zone=message.time_zone
             )
-            if exists:
-                upsert_result = await workbench.call_tool(
-                    "update-event",
-                    arguments={
-                        "calendarId": message.calendar_id,
-                        "eventId": message.event_id,
-                        "summary": message.summary,
-                        "start": normalized_start,
-                        "end": normalized_end,
-                        "timeZone": message.time_zone,
-                        "colorId": message.color_id,
-                        "description": message.description,
-                    },
+            target_event_id: str | None = message.event_id
+            if preexisting_cancelled and not exists:
+                target_event_id = None
+                logger.info(
+                    "Calendar upsert switched to server-generated event id for cancelled preexisting event: old=%s",
+                    message.event_id,
                 )
-            else:
-                upsert_result = await workbench.call_tool(
-                    "create-event",
-                    arguments={
-                        "calendarId": message.calendar_id,
-                        "eventId": message.event_id,
-                        "summary": message.summary,
-                        "start": normalized_start,
-                        "end": normalized_end,
-                        "timeZone": message.time_zone,
-                        "colorId": message.color_id,
-                        "description": message.description,
-                    },
-                )
+            upsert_arguments = {
+                "calendarId": message.calendar_id,
+                "summary": message.summary,
+                "start": normalized_start,
+                "end": normalized_end,
+                "timeZone": message.time_zone,
+                "colorId": message.color_id,
+                "description": message.description,
+            }
+            if target_event_id:
+                upsert_arguments["eventId"] = target_event_id
+            upsert_action = "update-event" if exists else "create-event"
+            if upsert_action == "create-event" and preexisting_cancelled:
+                upsert_arguments["allowDuplicates"] = True
+            upsert_result = await workbench.call_tool(
+                upsert_action,
+                arguments=upsert_arguments,
+            )
         except Exception as e:
             logger.error("Failed to upsert calendar event: %s", e, exc_info=True)
             return UpsertCalendarEventResult(
                 ok=False,
                 calendar_id=message.calendar_id,
-                event_id=message.event_id,
+                event_id=target_event_id or message.event_id,
                 error=str(e),
             )
 
         upsert_payload = self._extract_tool_payload(upsert_result)
+        if not target_event_id:
+            created_event = self._normalize_event(upsert_payload) or {}
+            payload_event_id = str(created_event.get("id") or "").strip()
+            if payload_event_id:
+                target_event_id = payload_event_id
         upsert_error = self._extract_tool_error(upsert_payload)
+        if (
+            upsert_error
+            and preexisting_cancelled
+            and not exists
+            and target_event_id
+            and "already exists" in upsert_error.lower()
+        ):
+            logger.info(
+                "Calendar cancelled-event recreate hit id collision; retrying as update: event_id=%s",
+                target_event_id,
+            )
+            try:
+                fallback_result = await workbench.call_tool(
+                    "update-event",
+                    arguments=upsert_arguments,
+                )
+            except Exception as exc:
+                return UpsertCalendarEventResult(
+                    ok=False,
+                    calendar_id=message.calendar_id,
+                    event_id=target_event_id,
+                    error=f"calendar fallback update failed: {exc}",
+                )
+            upsert_payload = self._extract_tool_payload(fallback_result)
+            upsert_error = self._extract_tool_error(upsert_payload)
+
         if upsert_error:
             logger.warning(
                 "Calendar upsert tool reported failure without exception: event_id=%s error=%s payload=%s",
-                message.event_id,
+                target_event_id,
                 upsert_error,
                 upsert_payload,
             )
             return UpsertCalendarEventResult(
                 ok=False,
                 calendar_id=message.calendar_id,
-                event_id=message.event_id,
+                event_id=target_event_id or message.event_id,
                 error=upsert_error,
+            )
+
+        if not target_event_id:
+            return UpsertCalendarEventResult(
+                ok=False,
+                calendar_id=message.calendar_id,
+                event_id=message.event_id,
+                error="calendar upsert returned no event id",
             )
 
         try:
@@ -560,7 +629,7 @@ class PlannerAgent(HauntAwareAgentMixin, RoutedAgent):
                 "get-event",
                 arguments={
                     "calendarId": message.calendar_id,
-                    "eventId": message.event_id,
+                    "eventId": target_event_id,
                 },
             )
             event = self._normalize_event(self._extract_tool_payload(fetched)) or {}
@@ -573,7 +642,7 @@ class PlannerAgent(HauntAwareAgentMixin, RoutedAgent):
             return UpsertCalendarEventResult(
                 ok=False,
                 calendar_id=message.calendar_id,
-                event_id=message.event_id,
+                event_id=target_event_id,
                 error=f"calendar verification fetch failed: {exc}",
             )
 
@@ -581,8 +650,16 @@ class PlannerAgent(HauntAwareAgentMixin, RoutedAgent):
             return UpsertCalendarEventResult(
                 ok=False,
                 calendar_id=message.calendar_id,
-                event_id=message.event_id,
+                event_id=target_event_id,
                 error="calendar verification returned no event payload",
+            )
+
+        if self._event_status(event) == "cancelled":
+            return UpsertCalendarEventResult(
+                ok=False,
+                calendar_id=message.calendar_id,
+                event_id=event.get("id") or target_event_id,
+                error="calendar verification returned cancelled event; event was not added",
             )
 
         matches, mismatch_reason = self._event_matches_upsert_request(
@@ -598,7 +675,7 @@ class PlannerAgent(HauntAwareAgentMixin, RoutedAgent):
             return UpsertCalendarEventResult(
                 ok=False,
                 calendar_id=message.calendar_id,
-                event_id=event.get("id") or message.event_id,
+                event_id=event.get("id") or target_event_id,
                 error=mismatch_reason or "calendar verification mismatch",
             )
 
@@ -607,18 +684,18 @@ class PlannerAgent(HauntAwareAgentMixin, RoutedAgent):
             return UpsertCalendarEventResult(
                 ok=False,
                 calendar_id=message.calendar_id,
-                event_id=event.get("id") or message.event_id,
+                event_id=event.get("id") or target_event_id,
                 error="calendar upsert verification succeeded but no event URL was returned",
             )
         logger.info(
             "Calendar event upserted successfully: event_id=%s, url=%s",
-            event.get("id") or message.event_id,
+            event.get("id") or target_event_id,
             event_url,
         )
         return UpsertCalendarEventResult(
             ok=True,
             calendar_id=message.calendar_id,
-            event_id=event.get("id") or message.event_id,
+            event_id=event.get("id") or target_event_id,
             event_url=str(event_url) if event_url else None,
         )
 

--- a/src/fateforger/haunt/event_draft_store.py
+++ b/src/fateforger/haunt/event_draft_store.py
@@ -179,7 +179,9 @@ class SqlAlchemyEventDraftStore:
             row.status = status.value
             if event_url is not None:
                 row.event_url = event_url
-            if last_error is not None:
+            if status is DraftStatus.SUCCESS:
+                row.last_error = None
+            elif last_error is not None:
                 row.last_error = last_error
             row.updated_at = datetime.utcnow()
             await session.commit()
@@ -217,4 +219,3 @@ __all__ = [
     "SqlAlchemyEventDraftStore",
     "ensure_event_draft_schema",
 ]
-

--- a/src/fateforger/haunt/planning_session_store.py
+++ b/src/fateforger/haunt/planning_session_store.py
@@ -72,6 +72,8 @@ class PlanningSessionRefPayload:
     source: str | None
     channel_id: str | None
     thread_ts: str | None
+    created_at: datetime
+    updated_at: datetime
 
 
 class SqlAlchemyPlanningSessionStore:
@@ -131,6 +133,7 @@ class SqlAlchemyPlanningSessionStore:
                 )
                 session.add(row)
             else:
+                row.planned_date = planned_date
                 row.calendar_id = calendar_id
                 row.event_id = event_id
                 row.status = status_value
@@ -209,6 +212,8 @@ def _to_payload(row: PlanningSessionRef) -> PlanningSessionRefPayload:
         source=row.source,
         channel_id=row.channel_id,
         thread_ts=row.thread_ts,
+        created_at=row.created_at,
+        updated_at=row.updated_at,
     )
 
 

--- a/src/fateforger/haunt/reconcile.py
+++ b/src/fateforger/haunt/reconcile.py
@@ -53,6 +53,8 @@ class PlanningRuleConfig:
     nudge_backoff_base: timedelta = timedelta(minutes=10)
     nudge_backoff_cap: timedelta = timedelta(hours=8)
     nudge_max_attempts: int = 5
+    # Grace window for eventual-consistency races right after local upsert success.
+    stored_session_consistency_grace: timedelta = timedelta(minutes=5)
     # TODO(refactor,typed-contracts): Remove summary keyword list and use a typed
     # event marker/label schema for planning-session detection.
     summary_keywords: tuple[str, ...] = ("plan", "planning", "review", "timebox")
@@ -158,19 +160,57 @@ class PlanningSessionRule:
     ) -> list[DesiredJob]:
         start = now.astimezone(timezone.utc)
         end = start + self._config.horizon
+        anchor_found = False
+        anchor_in_window = False
+        stored_hit = False
+        fallback_hit = False
+        list_count = 0
 
         if planning_event_id:
             anchor = await self._calendar_client.get_event(
                 calendar_id=self._config.calendar_id,
                 event_id=planning_event_id,
             )
-            if anchor and _event_within_window(anchor, start, end):
+            anchor_found = anchor is not None
+            anchor_in_window = bool(
+                anchor and _event_within_window(anchor, start, end)
+            )
+            if anchor_in_window:
+                self._log_evaluate_outcome(
+                    outcome="anchor_match",
+                    scope=scope,
+                    user_id=user_id,
+                    planning_event_id=planning_event_id,
+                    start=start,
+                    end=end,
+                    anchor_found=anchor_found,
+                    anchor_in_window=anchor_in_window,
+                    stored_hit=stored_hit,
+                    list_count=list_count,
+                    fallback_hit=fallback_hit,
+                    jobs_count=0,
+                )
                 return []
 
         stored = await self._resolve_planning_from_stored_sessions(
             user_id=user_id, start=start, end=end
         )
+        stored_hit = stored is not None
         if stored:
+            self._log_evaluate_outcome(
+                outcome="stored_match",
+                scope=scope,
+                user_id=user_id,
+                planning_event_id=planning_event_id,
+                start=start,
+                end=end,
+                anchor_found=anchor_found,
+                anchor_in_window=anchor_in_window,
+                stored_hit=stored_hit,
+                list_count=list_count,
+                fallback_hit=fallback_hit,
+                jobs_count=0,
+            )
             return []
 
         events = await self._calendar_client.list_events(
@@ -178,11 +218,27 @@ class PlanningSessionRule:
             time_min=start.isoformat(),
             time_max=end.isoformat(),
         )
+        list_count = len(events)
 
         fallback = self._resolve_planning_from_fallback(events, start=start, end=end)
+        fallback_hit = fallback is not None
         if fallback:
             await self._sync_fallback_session_record(
                 user_id=user_id, event=fallback, start=start
+            )
+            self._log_evaluate_outcome(
+                outcome="fallback_match",
+                scope=scope,
+                user_id=user_id,
+                planning_event_id=planning_event_id,
+                start=start,
+                end=end,
+                anchor_found=anchor_found,
+                anchor_in_window=anchor_in_window,
+                stored_hit=stored_hit,
+                list_count=list_count,
+                fallback_hit=fallback_hit,
+                jobs_count=0,
             )
             return []
 
@@ -231,8 +287,53 @@ class PlanningSessionRule:
                 ),
             )
         )
-
+        self._log_evaluate_outcome(
+            outcome="nudges_scheduled",
+            scope=scope,
+            user_id=user_id,
+            planning_event_id=planning_event_id,
+            start=start,
+            end=end,
+            anchor_found=anchor_found,
+            anchor_in_window=anchor_in_window,
+            stored_hit=stored_hit,
+            list_count=list_count,
+            fallback_hit=fallback_hit,
+            jobs_count=len(jobs),
+        )
         return jobs
+
+    def _log_evaluate_outcome(
+        self,
+        *,
+        outcome: str,
+        scope: str,
+        user_id: str | None,
+        planning_event_id: str | None,
+        start: datetime,
+        end: datetime,
+        anchor_found: bool,
+        anchor_in_window: bool,
+        stored_hit: bool,
+        list_count: int,
+        fallback_hit: bool,
+        jobs_count: int,
+    ) -> None:
+        logger.info(
+            "planning_reconcile evaluate outcome=%s scope=%s user_id=%s planning_event_id=%s window_start=%s window_end=%s anchor_found=%s anchor_in_window=%s stored_hit=%s list_count=%d fallback_hit=%s jobs_count=%d",
+            outcome,
+            scope,
+            user_id,
+            planning_event_id,
+            start.isoformat(),
+            end.isoformat(),
+            anchor_found,
+            anchor_in_window,
+            stored_hit,
+            list_count,
+            fallback_hit,
+            jobs_count,
+        )
 
     def _resolve_nudge_offsets(
         self, *, first_nudge_offset: timedelta | None
@@ -308,7 +409,35 @@ class PlanningSessionRule:
             )
             if event and _event_within_window(event, start, end):
                 return event
+            if self._is_recent_local_stored_session(session=session, now=start):
+                logger.info(
+                    "Using recent local planning_session_ref as consistency bridge (user=%s event_id=%s)",
+                    user_id,
+                    event_id,
+                )
+                return {
+                    "id": event_id,
+                    "summary": getattr(session, "title", None)
+                    or "Daily planning session",
+                }
         return None
+
+    def _is_recent_local_stored_session(self, *, session: Any, now: datetime) -> bool:
+        status = str(getattr(session, "status", "") or "").strip().lower()
+        if status not in {"planned", "in_progress"}:
+            return False
+        updated_at = getattr(session, "updated_at", None)
+        if not isinstance(updated_at, datetime):
+            return False
+        updated_utc = (
+            updated_at.replace(tzinfo=timezone.utc)
+            if updated_at.tzinfo is None
+            else updated_at.astimezone(timezone.utc)
+        )
+        delta = now.astimezone(timezone.utc) - updated_utc
+        if delta < timedelta(0):
+            delta = timedelta(0)
+        return delta <= self._config.stored_session_consistency_grace
 
     def _resolve_planning_from_fallback(
         self, events: Iterable[dict], *, start: datetime, end: datetime

--- a/src/fateforger/slack_bot/AGENTS.md
+++ b/src/fateforger/slack_bot/AGENTS.md
@@ -23,6 +23,7 @@
 - Operator path rule for live audits:
   - when sending test/user messages into Slack threads, use Slack MCP (`agent-slack`) as first choice.
   - use `scripts/dev/slack_user_timeboxing_driver.py` only as deterministic fallback when MCP access/auth is unavailable.
+- Before audit replays, restart the local bot process (`scripts/dev/slack_bot_dev.py`) and verify required MCP dependencies are up so results reflect current code.
 - `slack_route_dispatch_timeout` in `handlers.py` is a **delivery guard**, not proof that stage logic failed.
 - If timeout fallback text appears in Slack, correlate in this order:
   - session log: `graph_turn_start` / `graph_turn_end` for same `thread_ts` and stage
@@ -40,6 +41,14 @@
 - Action IDs must use the `FF_` or `ff_` prefix for discoverability.
 - Use Pydantic models for action payloads; avoid manual dict parsing of `body["actions"]`.
 - Modal submissions route through `handlers.py` view submission listeners.
+
+## Proposal Object Contract
+
+- For any Slack card/modal that represents a proposed object (event, task change, constraint change, etc.), treat Slack as a transport layer over a typed domain object.
+- NL thread replies and UI actions must converge to the same typed intent envelope and same submit executor; do not maintain separate business-logic paths.
+- NL interpretation must be schema-bound (typed AutoGen output or schema-in-prompt JSON contract), not regex/keyword/substring heuristics.
+- If a proposal supports user edits, edits must be represented as typed patch operations (or typed update fields) before execution.
+- Every proposal flow must log correlation fields (`proposal_id`, `intent_source`, `intent`, `submit_mode`) and have parity tests proving NL and UI execute the same backend path.
 
 ## Sync Engine Integration
 

--- a/src/fateforger/slack_bot/planning.py
+++ b/src/fateforger/slack_bot/planning.py
@@ -9,12 +9,16 @@ import uuid
 from dataclasses import dataclass
 from datetime import datetime, timedelta, timezone
 from time import perf_counter
-from typing import Any
+from typing import Any, Literal
 from urllib.parse import parse_qs, urlsplit
 from zoneinfo import ZoneInfo
 
+from autogen_agentchat.agents import AssistantAgent
+from autogen_agentchat.messages import TextMessage
+from autogen_core import CancellationToken
 from autogen_core import AgentId
 from dateutil import parser as date_parser
+from pydantic import BaseModel, Field, TypeAdapter
 from slack_sdk.web.async_client import AsyncWebClient
 
 from fateforger.agents.schedular.messages import (
@@ -50,6 +54,7 @@ from fateforger.haunt.reconcile import (
     PlanningSessionRule,
 )
 from fateforger.haunt.timeboxing_activity import timeboxing_activity
+from fateforger.llm import build_autogen_chat_client
 from fateforger.slack_bot.focus import FocusManager
 from fateforger.slack_bot.workspace import DEFAULT_PERSONAS, WorkspaceRegistry
 
@@ -80,12 +85,57 @@ DEFAULT_DURATION_OPTIONS = (15, 30, 45, 60, 90, 120)
 DEFAULT_DURATION_MINUTES = 30
 DEFAULT_TIMEZONE = "Europe/Amsterdam"
 
+PLANNING_THREAD_REPLY_INTERPRETER_PROMPT = """
+You interpret user replies in a planning-card thread.
+
+Your task:
+- Decide whether the reply should change the draft time and/or add the draft to calendar.
+- Return STRICT JSON matching PlanningThreadReplyDecision.
+
+Action definitions:
+- ignore: no planning-card action should run.
+- update_time: change draft time only (no add yet).
+- add_to_calendar: add draft without changing time.
+- update_time_and_add_to_calendar: change time, then add.
+
+Rules:
+- Understand natural language in any language.
+- If the user gives a clock time (e.g. 17:00, 5pm), normalize to 24h HH:MM.
+- Only set selected_time when user explicitly specifies a time.
+- If uncertain, choose action=ignore.
+- Never invent times.
+""".strip()
+
 
 @dataclass(frozen=True)
 class SlotSuggestion:
     start_utc: datetime
     end_utc: datetime
     tz: str
+
+
+class PlanningThreadReplyDecision(BaseModel):
+    action: Literal[
+        "ignore", "update_time", "add_to_calendar", "update_time_and_add_to_calendar"
+    ] = Field(
+        description="Interpretation action for this planning-card thread reply."
+    )
+    selected_time: str | None = Field(
+        default=None, description="24h time HH:MM when user explicitly requested one."
+    )
+    confidence: float | None = Field(
+        default=None, ge=0.0, le=1.0, description="Confidence score for telemetry."
+    )
+    explanation: str | None = Field(
+        default=None, description="Short debug rationale; not user-facing."
+    )
+
+
+@dataclass(frozen=True)
+class PlanningThreadReplyIntent:
+    should_handle: bool
+    commit: bool
+    selected_time: str | None
 
 
 class PlanningCoordinator:
@@ -108,8 +158,66 @@ class PlanningCoordinator:
         self._reconciler: PlanningReconciler | None = getattr(
             runtime, "planning_reconciler", None
         )
+        self._thread_reply_interpreter: AssistantAgent | None = None
         if self._guardian:
             timeboxing_activity.set_on_idle(self._handle_timeboxing_idle)
+
+    def _ensure_thread_reply_interpreter(self) -> AssistantAgent:
+        if self._thread_reply_interpreter:
+            return self._thread_reply_interpreter
+        self._thread_reply_interpreter = AssistantAgent(
+            name="planning_card_thread_reply_interpreter",
+            model_client=build_autogen_chat_client("planner_agent"),
+            output_content_type=PlanningThreadReplyDecision,
+            system_message=PLANNING_THREAD_REPLY_INTERPRETER_PROMPT,
+            reflect_on_tool_use=False,
+            max_tool_iterations=1,
+        )
+        return self._thread_reply_interpreter
+
+    async def _interpret_planning_thread_reply(
+        self, *, text: str, draft: EventDraftPayload
+    ) -> PlanningThreadReplyIntent:
+        interpreter = self._ensure_thread_reply_interpreter()
+        prompt = (
+            "Planning draft context:\n"
+            f"- title: {draft.title}\n"
+            f"- timezone: {draft.timezone}\n"
+            f"- current_start_utc: {draft.start_at_utc}\n"
+            f"- duration_min: {draft.duration_min}\n\n"
+            f"User reply:\n{text}"
+        )
+        try:
+            response = await interpreter.on_messages(
+                [TextMessage(content=prompt, source=draft.user_id)],
+                CancellationToken(),
+            )
+            content = getattr(getattr(response, "chat_message", None), "content", None)
+            if isinstance(content, PlanningThreadReplyDecision):
+                decision = content
+            else:
+                decision = TypeAdapter(PlanningThreadReplyDecision).validate_python(
+                    content
+                )
+        except Exception:
+            logger.warning("planning thread reply interpretation failed", exc_info=True)
+            return PlanningThreadReplyIntent(
+                should_handle=False, commit=False, selected_time=None
+            )
+
+        selected_time = (decision.selected_time or "").strip() or None
+        commit = decision.action in {
+            "add_to_calendar",
+            "update_time_and_add_to_calendar",
+        }
+        should_handle = decision.action != "ignore"
+        if decision.action in {"update_time", "update_time_and_add_to_calendar"}:
+            should_handle = bool(selected_time)
+        return PlanningThreadReplyIntent(
+            should_handle=should_handle,
+            commit=commit,
+            selected_time=selected_time,
+        )
 
     async def _handle_timeboxing_idle(self, user_id: str) -> None:
         if not self._guardian:
@@ -366,13 +474,13 @@ class PlanningCoordinator:
         if not self._reconciler:
             return True
 
+        now_utc = datetime.now(timezone.utc)
         try:
             rule = PlanningSessionRule(
                 calendar_client=self._reconciler.calendar_client,
                 planning_session_store=self._planning_session_store,
                 config=PlanningRuleConfig(calendar_id=calendar_id),
             )
-            now_utc = datetime.now(timezone.utc)
             desired = await rule.evaluate(
                 now=now_utc,
                 scope=reminder.scope,
@@ -380,14 +488,142 @@ class PlanningCoordinator:
                 channel_id=reminder.channel_id,
                 planning_event_id=planning_event_id,
             )
-            return bool(desired)
+            still_missing = bool(desired)
+            logger.info(
+                "dispatch_planning_reminder: revalidation_result user=%s scope=%s kind=%s attempt=%s calendar_id=%s planning_event_id=%s still_missing=%s desired_jobs=%d",
+                reminder.user_id,
+                reminder.scope,
+                reminder.kind,
+                reminder.attempt,
+                calendar_id,
+                planning_event_id,
+                still_missing,
+                len(desired),
+            )
+            if not still_missing:
+                refs = await self._list_local_upcoming_planning_refs(
+                    user_id=reminder.user_id,
+                    now_utc=now_utc,
+                )
+                await self._maybe_refresh_anchor_from_refs(
+                    reminder=reminder,
+                    calendar_id=calendar_id,
+                    planning_event_id=planning_event_id,
+                    refs=refs,
+                )
+            return still_missing
         except Exception:
             logger.exception(
-                "dispatch_planning_reminder: planning revalidation failed for user %s",
+                "dispatch_planning_reminder: planning revalidation failed for user=%s scope=%s kind=%s attempt=%s calendar_id=%s planning_event_id=%s",
                 reminder.user_id,
+                reminder.scope,
+                reminder.kind,
+                reminder.attempt,
+                calendar_id,
+                planning_event_id,
             )
-            # Fail-open so reminders still fire if revalidation is temporarily broken.
+            refs = await self._list_local_upcoming_planning_refs(
+                user_id=reminder.user_id,
+                now_utc=now_utc,
+            )
+            if refs:
+                await self._maybe_refresh_anchor_from_refs(
+                    reminder=reminder,
+                    calendar_id=calendar_id,
+                    planning_event_id=planning_event_id,
+                    refs=refs,
+                )
+                sampled_ids = ", ".join(
+                    sorted(
+                        {
+                            str(getattr(ref, "event_id", "") or "").strip()
+                            for ref in refs
+                            if str(getattr(ref, "event_id", "") or "").strip()
+                        }
+                    )[:3]
+                )
+                logger.warning(
+                    "dispatch_planning_reminder: fail-soft suppress reminder after revalidation failure user=%s scope=%s local_upcoming_refs=%d sampled_event_ids=%s",
+                    reminder.user_id,
+                    reminder.scope,
+                    len(refs),
+                    sampled_ids or "(none)",
+                )
+                return False
+            # No local evidence; fail-open so reminders still fire if revalidation is broken.
             return True
+
+    async def _list_local_upcoming_planning_refs(
+        self, *, user_id: str | None, now_utc: datetime
+    ) -> list[Any]:
+        if not user_id or not self._planning_session_store:
+            return []
+        horizon_end = now_utc + timedelta(hours=24)
+        try:
+            return await self._planning_session_store.list_for_user_between(
+                user_id=user_id,
+                start_date=now_utc.date(),
+                end_date=horizon_end.date(),
+                statuses=(
+                    PlanningSessionStatus.PLANNED,
+                    PlanningSessionStatus.IN_PROGRESS,
+                ),
+            )
+        except Exception:
+            logger.exception(
+                "dispatch_planning_reminder: local planning-session lookup failed for user=%s",
+                user_id,
+            )
+            return []
+
+    async def _maybe_refresh_anchor_from_refs(
+        self,
+        *,
+        reminder: PlanningReminder,
+        calendar_id: str,
+        planning_event_id: str,
+        refs: list[Any],
+    ) -> None:
+        if not self._anchor_store or not reminder.user_id or not refs:
+            return
+
+        def _sort_key(ref: Any) -> tuple[Any, float]:
+            planned = getattr(ref, "planned_date", None)
+            updated = getattr(ref, "updated_at", None)
+            updated_ts = updated.timestamp() if isinstance(updated, datetime) else 0.0
+            return (planned, -updated_ts)
+
+        ordered = sorted(refs, key=_sort_key)
+        for ref in ordered:
+            event_id = str(getattr(ref, "event_id", "") or "").strip()
+            ref_calendar_id = str(getattr(ref, "calendar_id", "") or "").strip()
+            if not event_id:
+                continue
+            if ref_calendar_id and ref_calendar_id != calendar_id:
+                continue
+            if event_id == planning_event_id:
+                return
+            try:
+                await self._anchor_store.upsert(
+                    user_id=reminder.user_id,
+                    channel_id=reminder.channel_id,
+                    calendar_id=calendar_id,
+                    event_id=event_id,
+                )
+                logger.info(
+                    "dispatch_planning_reminder: refreshed stale planning anchor user=%s old_event_id=%s new_event_id=%s",
+                    reminder.user_id,
+                    planning_event_id,
+                    event_id,
+                )
+            except Exception:
+                logger.exception(
+                    "dispatch_planning_reminder: failed to refresh planning anchor user=%s old_event_id=%s new_event_id=%s",
+                    reminder.user_id,
+                    planning_event_id,
+                    event_id,
+                )
+            return
 
     async def _post_admonishment_log(
         self, reminder: PlanningReminder, *, card_payload: dict[str, Any] | None = None
@@ -656,6 +892,156 @@ class PlanningCoordinator:
             component="planning_card", event="add_to_calendar", status="queued"
         )
 
+    async def maybe_handle_thread_reply(
+        self,
+        *,
+        channel_id: str,
+        thread_ts: str,
+        text: str,
+        thread_respond,
+    ) -> bool:
+        """Handle NL replies on planning-card threads using the same add path as card actions."""
+        if not self._draft_store:
+            return False
+        draft = await self._resolve_thread_draft(channel_id=channel_id, thread_ts=thread_ts)
+        if not draft:
+            return False
+
+        parsed = await self._interpret_planning_thread_reply(text=text, draft=draft)
+        if not parsed.should_handle:
+            return False
+
+        async def _card_respond(*, text: str, blocks, replace_original: bool) -> None:
+            payload: dict[str, Any] = {
+                "channel": channel_id,
+                "ts": thread_ts,
+                "text": text,
+            }
+            if blocks:
+                payload["blocks"] = blocks
+            await self._client.chat_update(**payload)
+
+        if parsed.selected_time:
+            draft_message_ts = (draft.message_ts or "").strip()
+            if not draft_message_ts:
+                return False
+            await self.handle_start_time_changed(
+                channel_id=draft.channel_id,
+                message_ts=draft_message_ts,
+                selected_time=parsed.selected_time,
+            )
+            if not parsed.commit:
+                updated_draft = await self._draft_store.get_by_draft_id(
+                    draft_id=draft.draft_id
+                )
+                if updated_draft:
+                    payload = _card_payload(
+                        updated_draft, status_override=_status_text(updated_draft)
+                    )
+                    await _card_respond(
+                        text=payload["text"],
+                        blocks=payload["blocks"],
+                        replace_original=True,
+                    )
+                await thread_respond(
+                    text=f"Updated draft time to {parsed.selected_time}. Press Add to calendar when ready."
+                )
+                return True
+            updated_draft = await self._draft_store.get_by_draft_id(
+                draft_id=draft.draft_id
+            )
+            if updated_draft:
+                draft = updated_draft
+
+        if parsed.commit:
+            if draft.status is DraftStatus.SUCCESS:
+                payload = _card_payload(draft)
+                await _card_respond(
+                    text=payload["text"],
+                    blocks=payload["blocks"],
+                    replace_original=True,
+                )
+                if draft.event_url:
+                    await thread_respond(
+                        text=(
+                            "This planning session is already on your calendar.\n"
+                            f"{draft.event_url}"
+                        )
+                    )
+                else:
+                    await thread_respond(
+                        text="This planning session is already on your calendar."
+                    )
+                return True
+            if draft.status is DraftStatus.PENDING:
+                await thread_respond(
+                    text="Still adding this planning session to your calendar…"
+                )
+                return True
+            await thread_respond(
+                text=(
+                    f"Applying your update at {parsed.selected_time} and adding to calendar…"
+                    if parsed.selected_time
+                    else "Adding this planning session to your calendar…"
+                )
+            )
+            await self.start_add_to_calendar(draft_id=draft.draft_id, respond=_card_respond)
+            return True
+
+        return False
+
+    async def _resolve_thread_draft(
+        self, *, channel_id: str, thread_ts: str
+    ) -> EventDraftPayload | None:
+        if not self._draft_store:
+            return None
+        direct = await self._draft_store.get_by_message(
+            channel_id=channel_id, message_ts=thread_ts
+        )
+        if direct:
+            return direct
+
+        draft_id = await self._extract_draft_id_from_thread_root(
+            channel_id=channel_id, thread_ts=thread_ts
+        )
+        if not draft_id:
+            return None
+        return await self._draft_store.get_by_draft_id(draft_id=draft_id)
+
+    async def _extract_draft_id_from_thread_root(
+        self, *, channel_id: str, thread_ts: str
+    ) -> str | None:
+        try:
+            response = await self._client.conversations_replies(
+                channel=channel_id,
+                ts=thread_ts,
+                inclusive=True,
+                limit=1,
+            )
+        except Exception:
+            logger.debug(
+                "planning thread draft-id resolve failed: channel=%s thread_ts=%s",
+                channel_id,
+                thread_ts,
+                exc_info=True,
+            )
+            return None
+
+        messages = response.get("messages") or []
+        if not messages:
+            return None
+        root = messages[0] if isinstance(messages[0], dict) else {}
+        for block in root.get("blocks") or []:
+            if not isinstance(block, dict):
+                continue
+            for element in block.get("elements") or []:
+                if not isinstance(element, dict):
+                    continue
+                draft_id = parse_draft_id_from_value(str(element.get("value") or ""))
+                if draft_id:
+                    return draft_id
+        return None
+
     async def _add_to_calendar_async(self, *, draft_id: str, respond) -> None:
         if not self._draft_store:
             logger.warning(
@@ -783,6 +1169,24 @@ class PlanningCoordinator:
                 except Exception:
                     logger.exception(
                         "Failed to upsert planning_session_ref for draft=%s",
+                        draft.draft_id,
+                    )
+            if (
+                self._anchor_store
+                and result_event_id
+                and result_event_id != draft.event_id
+            ):
+                try:
+                    await self._anchor_store.upsert(
+                        user_id=draft.user_id,
+                        channel_id=draft.channel_id,
+                        calendar_id=draft.calendar_id,
+                        event_id=result_event_id,
+                    )
+                except Exception:
+                    logger.exception(
+                        "Failed to update planning anchor event_id for user=%s draft=%s",
+                        draft.user_id,
                         draft.draft_id,
                     )
             if self._guardian:
@@ -939,7 +1343,10 @@ def _validate_google_calendar_event_url(url: str) -> str | None:
         return "Calendar upsert returned an incomplete event URL token; please retry."
     calendar_ref = parts[-1].strip()
     local, sep, domain = calendar_ref.partition("@")
-    if not local or not sep or not domain or "." not in domain:
+    # Some providers return abbreviated calendar refs in eid tokens
+    # (for example `user@m`) or aliases without `@` (for example `primary`).
+    # Treat only structurally broken refs as invalid.
+    if sep and (not local or not domain):
         return (
             "Calendar upsert returned an incomplete calendar reference; please retry."
         )

--- a/tests/unit/test_event_draft_store.py
+++ b/tests/unit/test_event_draft_store.py
@@ -1,0 +1,52 @@
+from datetime import datetime, timezone
+
+import pytest
+from sqlalchemy.ext.asyncio import async_sessionmaker, create_async_engine
+
+from fateforger.haunt.event_draft_store import (
+    DraftStatus,
+    SqlAlchemyEventDraftStore,
+    ensure_event_draft_schema,
+)
+
+
+@pytest.mark.asyncio
+async def test_event_draft_store_clears_last_error_on_success_status():
+    engine = create_async_engine("sqlite+aiosqlite:///:memory:")
+    try:
+        await ensure_event_draft_schema(engine)
+        sessionmaker = async_sessionmaker(engine, expire_on_commit=False)
+        store = SqlAlchemyEventDraftStore(sessionmaker)
+
+        draft = await store.create(
+            draft_id="draft_abc123",
+            user_id="U1",
+            channel_id="D1",
+            calendar_id="primary",
+            event_id="evt-1",
+            title="Daily planning session",
+            description="Plan tomorrow.",
+            timezone="Europe/Amsterdam",
+            start_at_utc=datetime(2026, 1, 18, 9, 0, tzinfo=timezone.utc).isoformat(),
+            duration_min=30,
+        )
+
+        failed = await store.update_status(
+            draft_id=draft.draft_id,
+            status=DraftStatus.FAILURE,
+            last_error="calendar upsert failed",
+        )
+        assert failed is not None
+        assert failed.last_error == "calendar upsert failed"
+
+        succeeded = await store.update_status(
+            draft_id=draft.draft_id,
+            status=DraftStatus.SUCCESS,
+            event_url="https://www.google.com/calendar/event?eid=abc",
+            last_error=None,
+        )
+        assert succeeded is not None
+        assert succeeded.status == DraftStatus.SUCCESS
+        assert succeeded.last_error is None
+    finally:
+        await engine.dispose()

--- a/tests/unit/test_planner_upsert_verification.py
+++ b/tests/unit/test_planner_upsert_verification.py
@@ -68,6 +68,145 @@ class _FakeUpsertWorkbench:
         raise AssertionError(f"Unexpected tool call: {name}")
 
 
+class _FakeCancelledVerificationWorkbench:
+    def __init__(self) -> None:
+        self.calls: list[tuple[str, dict]] = []
+        self._get_calls = 0
+
+    async def call_tool(self, name: str, arguments: dict):
+        self.calls.append((name, arguments))
+        if name == "get-event":
+            self._get_calls += 1
+            if self._get_calls == 1:
+                return _FakeToolResult(
+                    [
+                        _FakeTextResult(
+                            json.dumps(
+                                {
+                                    "event": {
+                                        "id": "evt-1",
+                                        "summary": "Daily planning session",
+                                        "start": {
+                                            "dateTime": "2026-02-27T18:20:51+01:00"
+                                        },
+                                        "end": {
+                                            "dateTime": "2026-02-27T18:50:51+01:00"
+                                        },
+                                        "htmlLink": "https://example.com/e/evt-1",
+                                    }
+                                }
+                            )
+                        )
+                    ]
+                )
+            return _FakeToolResult(
+                [
+                    _FakeTextResult(
+                        json.dumps(
+                            {
+                                "event": {
+                                    "id": "evt-1",
+                                    "status": "cancelled",
+                                    "summary": "Daily planning session",
+                                    "start": {
+                                        "dateTime": "2026-02-27T18:20:51+01:00"
+                                    },
+                                    "end": {
+                                        "dateTime": "2026-02-27T18:50:51+01:00"
+                                    },
+                                    "htmlLink": "https://example.com/e/evt-1",
+                                }
+                            }
+                        )
+                    )
+                ]
+            )
+        if name == "update-event":
+            return _FakeToolResult([_FakeTextResult(json.dumps({"ok": True}))])
+        raise AssertionError(f"Unexpected tool call: {name}")
+
+
+class _FakeCancelledPreexistingWorkbench:
+    def __init__(self) -> None:
+        self.calls: list[tuple[str, dict]] = []
+        self._get_calls = 0
+
+    async def call_tool(self, name: str, arguments: dict):
+        self.calls.append((name, arguments))
+        if name == "get-event":
+            self._get_calls += 1
+            if self._get_calls == 1:
+                return _FakeToolResult(
+                    [
+                        _FakeTextResult(
+                            json.dumps(
+                                {
+                                    "event": {
+                                        "id": "evt-1",
+                                        "status": "cancelled",
+                                        "summary": "Daily planning session",
+                                        "start": {
+                                            "dateTime": "2026-02-27T18:20:51+01:00"
+                                        },
+                                        "end": {
+                                            "dateTime": "2026-02-27T18:50:51+01:00"
+                                        },
+                                        "htmlLink": "https://example.com/e/evt-1",
+                                    }
+                                }
+                            )
+                        )
+                    ]
+                )
+            return _FakeToolResult(
+                [
+                    _FakeTextResult(
+                        json.dumps(
+                            {
+                                "event": {
+                                    "id": "evt-new",
+                                    "status": "confirmed",
+                                    "summary": "Daily planning session",
+                                    "start": {
+                                        "dateTime": "2026-02-27T18:20:51+01:00"
+                                    },
+                                    "end": {
+                                        "dateTime": "2026-02-27T18:50:51+01:00"
+                                    },
+                                    "htmlLink": "https://example.com/e/evt-1",
+                                }
+                            }
+                        )
+                    )
+                ]
+            )
+        if name == "delete-event":
+            return _FakeToolResult([_FakeTextResult(json.dumps({"ok": True}))])
+        if name == "create-event":
+            return _FakeToolResult(
+                [
+                    _FakeTextResult(
+                        json.dumps(
+                            {
+                                "event": {
+                                    "id": "evt-new",
+                                    "summary": "Daily planning session",
+                                    "start": {
+                                        "dateTime": "2026-02-27T18:20:51+01:00"
+                                    },
+                                    "end": {
+                                        "dateTime": "2026-02-27T18:50:51+01:00"
+                                    },
+                                    "htmlLink": "https://example.com/e/evt-new",
+                                }
+                            }
+                        )
+                    )
+                ]
+            )
+        raise AssertionError(f"Unexpected tool call: {name}")
+
+
 class _DummyHaunt:
     def register_agent(self, *args, **kwargs):
         return None
@@ -191,6 +330,53 @@ async def test_upsert_calendar_event_normalizes_start_end_for_update_event() -> 
     update_args = update_calls[0][1]
     assert update_args["start"] == "2026-02-27T18:20:51"
     assert update_args["end"] == "2026-02-27T18:50:51"
+
+
+@pytest.mark.asyncio
+async def test_upsert_calendar_event_fails_when_verification_event_is_cancelled() -> None:
+    workbench = _FakeCancelledVerificationWorkbench()
+    agent = PlannerAgent("planner_agent", haunt=_DummyHaunt())
+    agent._workbench = workbench
+    result = await agent.handle_upsert_calendar_event(
+        UpsertCalendarEvent(
+            calendar_id="primary",
+            event_id="evt-1",
+            summary="Daily planning session",
+            description="Plan tomorrow",
+            start="2026-02-27T17:20:51.252588+00:00",
+            end="2026-02-27T17:50:51.252588+00:00",
+            time_zone="Europe/Amsterdam",
+            color_id="10",
+        ),
+        None,
+    )
+    assert result.ok is False
+    assert "cancelled event" in (result.error or "")
+
+
+@pytest.mark.asyncio
+async def test_upsert_calendar_event_recreates_when_preexisting_event_is_cancelled() -> None:
+    workbench = _FakeCancelledPreexistingWorkbench()
+    agent = PlannerAgent("planner_agent", haunt=_DummyHaunt())
+    agent._workbench = workbench
+    result = await agent.handle_upsert_calendar_event(
+        UpsertCalendarEvent(
+            calendar_id="primary",
+            event_id="evt-1",
+            summary="Daily planning session",
+            description="Plan tomorrow",
+            start="2026-02-27T17:20:51.252588+00:00",
+            end="2026-02-27T17:50:51.252588+00:00",
+            time_zone="Europe/Amsterdam",
+            color_id="10",
+        ),
+        None,
+    )
+    assert result.ok is True
+    tool_names = [name for name, _ in workbench.calls]
+    assert "delete-event" in tool_names
+    assert "create-event" in tool_names
+    assert "update-event" not in tool_names
 
 
 def test_extract_tool_error_detects_structured_failure() -> None:

--- a/tests/unit/test_planning_add_to_calendar_flow.py
+++ b/tests/unit/test_planning_add_to_calendar_flow.py
@@ -1,22 +1,29 @@
+import asyncio
+
 import pytest
 
 pytest.importorskip("autogen_agentchat")
 
 from datetime import datetime, timezone
+from types import SimpleNamespace
 
 from autogen_core import AgentId
 
 from fateforger.agents.schedular.messages import UpsertCalendarEvent, UpsertCalendarEventResult
 from fateforger.haunt.event_draft_store import DraftStatus, EventDraftPayload
-from fateforger.slack_bot.planning import PlanningCoordinator
+from fateforger.slack_bot.planning import PlanningCoordinator, PlanningThreadReplyIntent
 
 VALID_EVENT_URL = (
     "https://www.google.com/calendar/event?eid="
     "ZmZwbGFubmluZ3h5eiBodWdvLmV2ZXJzQGV4YW1wbGUuY29t"
 )
-INVALID_EVENT_URL = (
+SHORT_DOMAIN_EVENT_URL = (
     "https://www.google.com/calendar/event?eid="
     "ZmZwbGFubmluZ3h5eiBodWdvLmV2ZXJzQG0"
+)
+MALFORMED_EID_EVENT_URL = (
+    "https://www.google.com/calendar/event?eid="
+    "ZmZwbGFubmluZ3h5eg"
 )
 
 
@@ -25,9 +32,32 @@ class _FakeDraftStore:
         self._draft = draft
         self.status_updates = []
 
+    async def get_by_message(self, *, channel_id: str, message_ts: str):
+        if channel_id != self._draft.channel_id or message_ts != self._draft.message_ts:
+            return None
+        return self._draft
+
     async def get_by_draft_id(self, *, draft_id: str):
         if draft_id != self._draft.draft_id:
             return None
+        return self._draft
+
+    async def update_time(
+        self,
+        *,
+        channel_id: str,
+        message_ts: str,
+        start_at_utc: str | None = None,
+        duration_min: int | None = None,
+    ):
+        if channel_id != self._draft.channel_id or message_ts != self._draft.message_ts:
+            return None
+        updates = dict(self._draft.__dict__)
+        if start_at_utc is not None:
+            updates["start_at_utc"] = start_at_utc
+        if duration_min is not None:
+            updates["duration_min"] = duration_min
+        self._draft = self._draft.__class__(**updates)
         return self._draft
 
     async def update_status(self, *, draft_id: str, status: DraftStatus, event_url=None, last_error=None):
@@ -54,6 +84,24 @@ class _FakePlanningSessionStore:
     async def upsert(self, **kwargs):
         self.upserts.append(kwargs)
         return kwargs
+
+
+class _FakeAnchorStore:
+    def __init__(self):
+        self.upserts = []
+
+    async def upsert(self, **kwargs):
+        self.upserts.append(kwargs)
+        return kwargs
+
+
+class _FakeClient:
+    def __init__(self):
+        self.updates = []
+
+    async def chat_update(self, **kwargs):
+        self.updates.append(kwargs)
+        return {"ok": True}
 
 
 @pytest.mark.asyncio
@@ -204,6 +252,53 @@ async def test_add_to_calendar_ok_without_url_treated_as_failure():
 
 
 @pytest.mark.asyncio
+async def test_add_to_calendar_ok_with_short_domain_google_eid_treated_as_success():
+    draft = EventDraftPayload(
+        draft_id="draft_abc123",
+        user_id="U1",
+        channel_id="D1",
+        message_ts="123.456",
+        calendar_id="primary",
+        event_id="ffplanningxyz",
+        title="Daily planning session",
+        description="Plan tomorrow.",
+        timezone="Europe/Amsterdam",
+        start_at_utc=datetime(2026, 1, 18, 9, 0, tzinfo=timezone.utc).isoformat(),
+        duration_min=30,
+        status=DraftStatus.PENDING,
+        event_url=None,
+        last_error=None,
+    )
+    store = _FakeDraftStore(draft)
+    runtime = _DummyRuntime(
+        UpsertCalendarEventResult(
+            ok=True,
+            calendar_id="primary",
+            event_id="ffplanningxyz",
+            event_url=SHORT_DOMAIN_EVENT_URL,
+        )
+    )
+
+    coordinator = PlanningCoordinator(runtime=runtime, focus=object(), client=object())  # type: ignore[arg-type]
+    coordinator._draft_store = store  # type: ignore[attr-defined]
+    coordinator._guardian = None  # type: ignore[attr-defined]
+
+    updates = []
+
+    async def respond(*, text, blocks, replace_original):
+        updates.append({"text": text, "blocks": blocks, "replace_original": replace_original})
+
+    await coordinator._add_to_calendar_async(draft_id=draft.draft_id, respond=respond)
+
+    assert store.status_updates
+    status, _event_url, last_error = store.status_updates[-1]
+    assert status == DraftStatus.SUCCESS
+    assert last_error is None
+    assert _event_url == SHORT_DOMAIN_EVENT_URL
+    assert updates
+
+
+@pytest.mark.asyncio
 async def test_add_to_calendar_ok_with_malformed_google_eid_treated_as_failure():
     draft = EventDraftPayload(
         draft_id="draft_abc123",
@@ -227,7 +322,7 @@ async def test_add_to_calendar_ok_with_malformed_google_eid_treated_as_failure()
             ok=True,
             calendar_id="primary",
             event_id="ffplanningxyz",
-            event_url=INVALID_EVENT_URL,
+            event_url=MALFORMED_EID_EVENT_URL,
         )
     )
 
@@ -245,5 +340,281 @@ async def test_add_to_calendar_ok_with_malformed_google_eid_treated_as_failure()
     assert store.status_updates
     status, _event_url, last_error = store.status_updates[-1]
     assert status == DraftStatus.FAILURE
-    assert "incomplete calendar reference" in (last_error or "").lower()
+    assert "incomplete event url token" in (last_error or "").lower()
     assert updates
+
+
+@pytest.mark.asyncio
+async def test_add_to_calendar_success_updates_anchor_when_event_id_changes():
+    draft = EventDraftPayload(
+        draft_id="draft_abc123",
+        user_id="U1",
+        channel_id="D1",
+        message_ts="123.456",
+        calendar_id="primary",
+        event_id="ffplanningxyz",
+        title="Daily planning session",
+        description="Plan tomorrow.",
+        timezone="Europe/Amsterdam",
+        start_at_utc=datetime(2026, 1, 18, 9, 0, tzinfo=timezone.utc).isoformat(),
+        duration_min=30,
+        status=DraftStatus.PENDING,
+        event_url=None,
+        last_error=None,
+    )
+    store = _FakeDraftStore(draft)
+    runtime = _DummyRuntime(
+        UpsertCalendarEventResult(
+            ok=True,
+            calendar_id="primary",
+            event_id="ffplanningxyz-20260306",
+            event_url=VALID_EVENT_URL,
+        )
+    )
+
+    coordinator = PlanningCoordinator(runtime=runtime, focus=object(), client=object())  # type: ignore[arg-type]
+    coordinator._draft_store = store  # type: ignore[attr-defined]
+    coordinator._guardian = None  # type: ignore[attr-defined]
+    anchor_store = _FakeAnchorStore()
+    coordinator._anchor_store = anchor_store  # type: ignore[attr-defined]
+
+    updates = []
+
+    async def respond(*, text, blocks, replace_original):
+        updates.append({"text": text, "blocks": blocks, "replace_original": replace_original})
+
+    await coordinator._add_to_calendar_async(draft_id=draft.draft_id, respond=respond)
+
+    assert anchor_store.upserts
+    assert anchor_store.upserts[-1]["event_id"] == "ffplanningxyz-20260306"
+    assert updates
+
+
+@pytest.mark.asyncio
+async def test_thread_reply_update_and_commit_uses_same_add_to_calendar_path(monkeypatch):
+    draft = EventDraftPayload(
+        draft_id="draft_abc123",
+        user_id="U1",
+        channel_id="D1",
+        message_ts="123.456",
+        calendar_id="primary",
+        event_id="ffplanningxyz",
+        title="Daily planning session",
+        description="Plan tomorrow.",
+        timezone="Europe/Amsterdam",
+        start_at_utc=datetime(2026, 1, 18, 9, 0, tzinfo=timezone.utc).isoformat(),
+        duration_min=30,
+        status=DraftStatus.DRAFT,
+        event_url=None,
+        last_error=None,
+    )
+    store = _FakeDraftStore(draft)
+    runtime = _DummyRuntime(
+        UpsertCalendarEventResult(
+            ok=True,
+            calendar_id="primary",
+            event_id="ffplanningxyz",
+            event_url=VALID_EVENT_URL,
+        )
+    )
+    client = _FakeClient()
+
+    coordinator = PlanningCoordinator(runtime=runtime, focus=object(), client=client)  # type: ignore[arg-type]
+    coordinator._draft_store = store  # type: ignore[attr-defined]
+    coordinator._guardian = None  # type: ignore[attr-defined]
+
+    async def _fake_interpret(*, text: str, draft: EventDraftPayload):
+        assert text == "yes plan it at 17:00"
+        assert draft.draft_id == "draft_abc123"
+        return PlanningThreadReplyIntent(
+            should_handle=True, commit=True, selected_time="17:00"
+        )
+
+    coordinator._interpret_planning_thread_reply = _fake_interpret  # type: ignore[method-assign]
+
+    scheduled: list[asyncio.Task] = []
+    original_create_task = asyncio.create_task
+
+    def _capture_task(coro):
+        task = original_create_task(coro)
+        scheduled.append(task)
+        return task
+
+    monkeypatch.setattr("fateforger.slack_bot.planning.asyncio.create_task", _capture_task)
+
+    thread_updates = []
+
+    async def _thread_respond(*, text: str, blocks=None):
+        thread_updates.append({"text": text, "blocks": blocks})
+
+    handled = await coordinator.maybe_handle_thread_reply(
+        channel_id="D1",
+        thread_ts="123.456",
+        text="yes plan it at 17:00",
+        thread_respond=_thread_respond,
+    )
+
+    assert handled is True
+    assert scheduled, "expected add-to-calendar async task to be scheduled"
+    await asyncio.gather(*scheduled)
+
+    assert runtime.calls
+    sent, recipient = runtime.calls[-1]
+    assert isinstance(sent, UpsertCalendarEvent)
+    assert recipient.type == "planner_agent"
+    assert sent.start == "2026-01-18T17:00:00"
+    assert sent.end == "2026-01-18T17:30:00"
+    assert store.status_updates[-1][0] == DraftStatus.SUCCESS
+    assert client.updates, "expected card updates via chat_update"
+    assert thread_updates
+
+
+@pytest.mark.asyncio
+async def test_interpret_thread_reply_requires_structured_output():
+    draft = EventDraftPayload(
+        draft_id="draft_abc123",
+        user_id="U1",
+        channel_id="D1",
+        message_ts="123.456",
+        calendar_id="primary",
+        event_id="ffplanningxyz",
+        title="Daily planning session",
+        description="Plan tomorrow.",
+        timezone="Europe/Amsterdam",
+        start_at_utc=datetime(2026, 1, 18, 9, 0, tzinfo=timezone.utc).isoformat(),
+        duration_min=30,
+        status=DraftStatus.DRAFT,
+        event_url=None,
+        last_error=None,
+    )
+    coordinator = PlanningCoordinator(runtime=object(), focus=object(), client=object())  # type: ignore[arg-type]
+
+    class _StructuredInterpreter:
+        async def on_messages(self, _messages, _cancellation):
+            return SimpleNamespace(
+                chat_message=SimpleNamespace(
+                    content={
+                        "action": "update_time_and_add_to_calendar",
+                        "selected_time": "17:00",
+                    }
+                )
+            )
+
+    coordinator._ensure_thread_reply_interpreter = lambda: _StructuredInterpreter()  # type: ignore[method-assign]
+
+    parsed = await coordinator._interpret_planning_thread_reply(
+        text="yes plan it at 17:00", draft=draft
+    )
+
+    assert parsed.should_handle is True
+    assert parsed.commit is True
+    assert parsed.selected_time == "17:00"
+
+
+@pytest.mark.asyncio
+async def test_thread_reply_has_no_text_heuristic_fallback_when_interpreter_fails():
+    draft = EventDraftPayload(
+        draft_id="draft_abc123",
+        user_id="U1",
+        channel_id="D1",
+        message_ts="123.456",
+        calendar_id="primary",
+        event_id="ffplanningxyz",
+        title="Daily planning session",
+        description="Plan tomorrow.",
+        timezone="Europe/Amsterdam",
+        start_at_utc=datetime(2026, 1, 18, 9, 0, tzinfo=timezone.utc).isoformat(),
+        duration_min=30,
+        status=DraftStatus.DRAFT,
+        event_url=None,
+        last_error=None,
+    )
+    store = _FakeDraftStore(draft)
+    runtime = _DummyRuntime(
+        UpsertCalendarEventResult(
+            ok=True,
+            calendar_id="primary",
+            event_id="ffplanningxyz",
+            event_url=VALID_EVENT_URL,
+        )
+    )
+    coordinator = PlanningCoordinator(runtime=runtime, focus=object(), client=object())  # type: ignore[arg-type]
+    coordinator._draft_store = store  # type: ignore[attr-defined]
+    coordinator._guardian = None  # type: ignore[attr-defined]
+
+    class _BrokenInterpreter:
+        async def on_messages(self, _messages, _cancellation):
+            return SimpleNamespace(chat_message=SimpleNamespace(content={"foo": "bar"}))
+
+    coordinator._ensure_thread_reply_interpreter = lambda: _BrokenInterpreter()  # type: ignore[method-assign]
+
+    handled = await coordinator.maybe_handle_thread_reply(
+        channel_id="D1",
+        thread_ts="123.456",
+        text="yes plan it at 17:00",
+        thread_respond=lambda **_kwargs: None,
+    )
+
+    assert handled is False
+    assert runtime.calls == []
+    assert store.status_updates == []
+
+
+@pytest.mark.asyncio
+async def test_thread_reply_commit_on_success_draft_returns_terminal_noop_message():
+    draft = EventDraftPayload(
+        draft_id="draft_abc123",
+        user_id="U1",
+        channel_id="D1",
+        message_ts="123.456",
+        calendar_id="primary",
+        event_id="ffplanningxyz",
+        title="Daily planning session",
+        description="Plan tomorrow.",
+        timezone="Europe/Amsterdam",
+        start_at_utc=datetime(2026, 1, 18, 9, 0, tzinfo=timezone.utc).isoformat(),
+        duration_min=30,
+        status=DraftStatus.SUCCESS,
+        event_url=VALID_EVENT_URL,
+        last_error=None,
+    )
+    store = _FakeDraftStore(draft)
+    runtime = _DummyRuntime(
+        UpsertCalendarEventResult(
+            ok=True,
+            calendar_id="primary",
+            event_id="ffplanningxyz",
+            event_url=VALID_EVENT_URL,
+        )
+    )
+    client = _FakeClient()
+
+    coordinator = PlanningCoordinator(runtime=runtime, focus=object(), client=client)  # type: ignore[arg-type]
+    coordinator._draft_store = store  # type: ignore[attr-defined]
+    coordinator._guardian = None  # type: ignore[attr-defined]
+
+    async def _fake_interpret(*, text: str, draft: EventDraftPayload):
+        assert text == "yes plan it at 17:00"
+        return PlanningThreadReplyIntent(
+            should_handle=True, commit=True, selected_time=None
+        )
+
+    coordinator._interpret_planning_thread_reply = _fake_interpret  # type: ignore[method-assign]
+
+    thread_updates = []
+
+    async def _thread_respond(*, text: str, blocks=None):
+        thread_updates.append({"text": text, "blocks": blocks})
+
+    handled = await coordinator.maybe_handle_thread_reply(
+        channel_id="D1",
+        thread_ts="123.456",
+        text="yes plan it at 17:00",
+        thread_respond=_thread_respond,
+    )
+
+    assert handled is True
+    assert runtime.calls == []
+    assert client.updates
+    assert thread_updates
+    assert "already on your calendar" in thread_updates[-1]["text"].lower()

--- a/tests/unit/test_planning_reminder_suppression.py
+++ b/tests/unit/test_planning_reminder_suppression.py
@@ -1,4 +1,7 @@
 from datetime import datetime, timedelta, timezone
+import logging
+from dataclasses import dataclass
+from datetime import date
 
 import pytest
 
@@ -33,9 +36,35 @@ class _DummyCalendarClient:
         return list(self._events)
 
 
+class _BrokenCalendarClient(_DummyCalendarClient):
+    async def list_events(self, *, calendar_id: str, time_min: str, time_max: str):  # noqa: ARG002
+        raise RuntimeError("calendar list failed")
+
+
 class _DummyPlanningStore:
+    def __init__(self, sessions=None):
+        self._sessions = list(sessions or [])
+
     async def list_for_user_between(self, **kwargs):  # noqa: ARG002
-        return []
+        user_id = kwargs.get("user_id")
+        start_date = kwargs.get("start_date")
+        end_date = kwargs.get("end_date")
+        statuses = kwargs.get("statuses") or ()
+        allowed = {
+            str(getattr(item, "value", item)).strip().lower() for item in statuses
+        }
+        rows = []
+        for session in self._sessions:
+            if user_id and session.user_id != user_id:
+                continue
+            if start_date and session.planned_date < start_date:
+                continue
+            if end_date and session.planned_date > end_date:
+                continue
+            if allowed and session.status.lower() not in allowed:
+                continue
+            rows.append(session)
+        return rows
 
     async def upsert(self, **kwargs):  # noqa: ARG002
         return None
@@ -44,6 +73,25 @@ class _DummyPlanningStore:
 class _DummyReconciler:
     def __init__(self, calendar_client):
         self.calendar_client = calendar_client
+
+
+class _DummyAnchorStore:
+    def __init__(self):
+        self.upserts = []
+
+    async def upsert(self, **kwargs):
+        self.upserts.append(kwargs)
+        return kwargs
+
+
+@dataclass
+class _SessionRef:
+    user_id: str
+    planned_date: date
+    calendar_id: str
+    event_id: str
+    status: str = "planned"
+    updated_at: datetime = datetime(2026, 3, 6, 21, 0, tzinfo=timezone.utc)
 
 
 @pytest.mark.asyncio
@@ -118,3 +166,144 @@ async def test_dispatch_skips_stale_reminder_when_planning_now_exists():
     )
 
     assert client.posted == []
+
+
+@pytest.mark.asyncio
+async def test_planning_still_missing_logs_revalidation_exception_context(caplog):
+    runtime = type(
+        "Runtime",
+        (),
+        {
+            "event_draft_store": object(),
+            "planning_guardian": None,
+            "planning_session_store": _DummyPlanningStore(),
+            "planning_reconciler": _DummyReconciler(_BrokenCalendarClient(events=[])),
+        },
+    )()
+    client = DummyClient()
+    coordinator = PlanningCoordinator(runtime=runtime, focus=object(), client=client)  # type: ignore[arg-type]
+
+    reminder = PlanningReminder(
+        scope="U1",
+        kind="nudge2",
+        attempt=2,
+        message="still missing",
+        user_id="U1",
+        channel_id="D1",
+    )
+
+    with caplog.at_level(logging.INFO):
+        still_missing = await coordinator._planning_still_missing(
+            reminder=reminder,
+            planning_event_id="ffplanning-stale",
+            calendar_id="primary",
+        )
+
+    assert still_missing is True
+    assert "planning revalidation failed" in caplog.text
+    assert "scope=U1" in caplog.text
+    assert "kind=nudge2" in caplog.text
+    assert "planning_event_id=ffplanning-stale" in caplog.text
+
+
+@pytest.mark.asyncio
+async def test_planning_still_missing_fail_soft_when_local_upcoming_ref_exists():
+    runtime = type(
+        "Runtime",
+        (),
+        {
+            "event_draft_store": object(),
+            "planning_guardian": None,
+            "planning_session_store": _DummyPlanningStore(
+                sessions=[
+                    _SessionRef(
+                        user_id="U1",
+                        planned_date=date(2026, 3, 7),
+                        calendar_id="primary",
+                        event_id="canonical-event-123",
+                    )
+                ]
+            ),
+            "planning_reconciler": _DummyReconciler(_BrokenCalendarClient(events=[])),
+            "planning_anchor_store": _DummyAnchorStore(),
+        },
+    )()
+    client = DummyClient()
+    coordinator = PlanningCoordinator(runtime=runtime, focus=object(), client=client)  # type: ignore[arg-type]
+
+    reminder = PlanningReminder(
+        scope="U1",
+        kind="nudge2",
+        attempt=2,
+        message="still missing",
+        user_id="U1",
+        channel_id="D1",
+    )
+
+    still_missing = await coordinator._planning_still_missing(
+        reminder=reminder,
+        planning_event_id="stale-event-999",
+        calendar_id="primary",
+    )
+
+    assert still_missing is False
+    assert runtime.planning_anchor_store.upserts
+    assert runtime.planning_anchor_store.upserts[-1]["event_id"] == "canonical-event-123"
+
+
+@pytest.mark.asyncio
+async def test_planning_still_missing_refreshes_anchor_on_success_path():
+    start = datetime.now(timezone.utc) + timedelta(hours=1)
+    end = start + timedelta(minutes=30)
+    runtime = type(
+        "Runtime",
+        (),
+        {
+            "event_draft_store": object(),
+            "planning_guardian": None,
+            "planning_session_store": _DummyPlanningStore(
+                sessions=[
+                    _SessionRef(
+                        user_id="U1",
+                        planned_date=start.date(),
+                        calendar_id="primary",
+                        event_id="canonical-event-abc",
+                    )
+                ]
+            ),
+            "planning_reconciler": _DummyReconciler(
+                _DummyCalendarClient(
+                    events=[
+                        {
+                            "id": "canonical-event-abc",
+                            "summary": "Daily planning session",
+                            "start": {"dateTime": start.isoformat()},
+                            "end": {"dateTime": end.isoformat()},
+                        }
+                    ]
+                )
+            ),
+            "planning_anchor_store": _DummyAnchorStore(),
+        },
+    )()
+    client = DummyClient()
+    coordinator = PlanningCoordinator(runtime=runtime, focus=object(), client=client)  # type: ignore[arg-type]
+
+    reminder = PlanningReminder(
+        scope="U1",
+        kind="nudge1",
+        attempt=1,
+        message="nudge",
+        user_id="U1",
+        channel_id="D1",
+    )
+
+    still_missing = await coordinator._planning_still_missing(
+        reminder=reminder,
+        planning_event_id="stale-event-999",
+        calendar_id="primary",
+    )
+
+    assert still_missing is False
+    assert runtime.planning_anchor_store.upserts
+    assert runtime.planning_anchor_store.upserts[-1]["event_id"] == "canonical-event-abc"

--- a/tests/unit/test_planning_session_store.py
+++ b/tests/unit/test_planning_session_store.py
@@ -40,10 +40,12 @@ async def test_planning_session_store_upsert_and_lookup_with_string_status():
         assert len(rows) == 1
         assert rows[0].event_id == "evt-1"
         assert rows[0].status == "planned"
+        assert rows[0].updated_at >= rows[0].created_at
 
         by_event = await store.get_by_event_id(calendar_id="primary", event_id="evt-1")
         assert by_event is not None
         assert by_event.event_url == "https://calendar.google.com/event?eid=abc"
+        assert by_event.updated_at >= by_event.created_at
     finally:
         await engine.dispose()
 
@@ -83,5 +85,48 @@ async def test_planning_session_store_upsert_updates_existing_user_day():
         assert len(rows) == 1
         assert rows[0].event_id == "evt-2"
         assert rows[0].status == "in_progress"
+    finally:
+        await engine.dispose()
+
+
+@pytest.mark.asyncio
+async def test_planning_session_store_upsert_updates_planned_date_on_calendar_event_match():
+    engine = create_async_engine("sqlite+aiosqlite:///:memory:")
+    try:
+        await ensure_planning_session_schema(engine)
+        sessionmaker = async_sessionmaker(engine, expire_on_commit=False)
+        store = SqlAlchemyPlanningSessionStore(sessionmaker)
+
+        await store.upsert(
+            user_id="U1",
+            planned_date=date(2025, 1, 1),
+            calendar_id="primary",
+            event_id="evt-1",
+            status=PlanningSessionStatus.PLANNED,
+        )
+        await store.upsert(
+            user_id="U1",
+            planned_date=date(2025, 1, 2),
+            calendar_id="primary",
+            event_id="evt-1",
+            status=PlanningSessionStatus.PLANNED,
+        )
+
+        old_day_rows = await store.list_for_user_between(
+            user_id="U1",
+            start_date=date(2025, 1, 1),
+            end_date=date(2025, 1, 1),
+            statuses=(PlanningSessionStatus.PLANNED,),
+        )
+        assert old_day_rows == []
+
+        new_day_rows = await store.list_for_user_between(
+            user_id="U1",
+            start_date=date(2025, 1, 2),
+            end_date=date(2025, 1, 2),
+            statuses=(PlanningSessionStatus.PLANNED,),
+        )
+        assert len(new_day_rows) == 1
+        assert new_day_rows[0].event_id == "evt-1"
     finally:
         await engine.dispose()

--- a/tests/unit/test_reconcile.py
+++ b/tests/unit/test_reconcile.py
@@ -1,5 +1,6 @@
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from datetime import date, datetime, timedelta, timezone
+import logging
 
 import pytest
 
@@ -46,6 +47,12 @@ class _StoredSession:
     source: str | None = None
     channel_id: str | None = None
     thread_ts: str | None = None
+    created_at: datetime = field(
+        default_factory=lambda: datetime.now(timezone.utc).replace(tzinfo=None)
+    )
+    updated_at: datetime = field(
+        default_factory=lambda: datetime.now(timezone.utc).replace(tzinfo=None)
+    )
 
 
 class FakePlanningSessionStore:
@@ -193,6 +200,32 @@ async def test_reconcile_uses_anchor_event_id_when_provided():
 
 
 @pytest.mark.asyncio
+async def test_reconcile_logs_outcome_for_anchor_match(caplog):
+    scheduler = FakeScheduler()
+    client = DummyCalendarClient(events=[])
+    reconciler = PlanningReconciler(scheduler, calendar_client=client)
+
+    now = datetime(2025, 1, 1, 9, 0, tzinfo=timezone.utc)
+    client.event_lookup[("primary", "ff-planning-u1")] = {
+        "id": "ff-planning-u1",
+        "start": {"dateTime": "2025-01-01T10:00:00+00:00"},
+        "end": {"dateTime": "2025-01-01T10:30:00+00:00"},
+    }
+
+    with caplog.at_level(logging.INFO, logger="fateforger.haunt.reconcile"):
+        jobs = await reconciler.reconcile_missing_planning(
+            scope="U1",
+            user_id="U1",
+            channel_id="C1",
+            planning_event_id="ff-planning-u1",
+            now=now,
+        )
+
+    assert jobs == []
+    assert "planning_reconcile evaluate outcome=anchor_match" in caplog.text
+
+
+@pytest.mark.asyncio
 async def test_reconcile_ignores_anchor_event_outside_window():
     scheduler = FakeScheduler()
     client = DummyCalendarClient(events=[])
@@ -273,6 +306,26 @@ async def test_reconcile_accepts_timeboxing_fallback_event():
     assert jobs == []
     assert store.upserts
     assert store.upserts[-1]["event_id"] == "evt-timeboxing"
+
+
+@pytest.mark.asyncio
+async def test_reconcile_logs_outcome_for_nudges_scheduled(caplog):
+    scheduler = FakeScheduler()
+    client = DummyCalendarClient(events=[])
+    reconciler = PlanningReconciler(scheduler, calendar_client=client)
+
+    now = datetime(2025, 1, 1, 9, 0, tzinfo=timezone.utc)
+    with caplog.at_level(logging.INFO, logger="fateforger.haunt.reconcile"):
+        jobs = await reconciler.reconcile_missing_planning(
+            scope="U1",
+            user_id="U1",
+            channel_id="C1",
+            planning_event_id="ff-planning-u1",
+            now=now,
+        )
+
+    assert len(jobs) == 6
+    assert "planning_reconcile evaluate outcome=nudges_scheduled" in caplog.text
 
 
 @pytest.mark.asyncio
@@ -383,3 +436,69 @@ async def test_reconcile_fallback_prefers_deterministic_ffplanning_id():
     assert jobs == []
     assert store.upserts
     assert store.upserts[-1]["event_id"] == "ffplanning-u1"
+
+
+@pytest.mark.asyncio
+async def test_reconcile_trusts_recent_local_stored_session_when_calendar_read_lags():
+    scheduler = FakeScheduler()
+    client = DummyCalendarClient(events=[])
+    store = FakePlanningSessionStore(
+        sessions=[
+            _StoredSession(
+                user_id="U1",
+                planned_date=date(2025, 1, 1),
+                calendar_id="primary",
+                event_id="ffplanningu1",
+                status="planned",
+                source="admonisher_planning_card",
+                updated_at=datetime(2025, 1, 1, 9, 0, 0),
+            )
+        ]
+    )
+    reconciler = PlanningReconciler(
+        scheduler, calendar_client=client, planning_session_store=store
+    )
+
+    now = datetime(2025, 1, 1, 9, 1, tzinfo=timezone.utc)
+    jobs = await reconciler.reconcile_missing_planning(
+        scope="U1",
+        user_id="U1",
+        channel_id="C1",
+        now=now,
+    )
+
+    assert jobs == []
+    assert scheduler.get_jobs() == []
+
+
+@pytest.mark.asyncio
+async def test_reconcile_does_not_trust_stale_local_stored_session_without_calendar_event():
+    scheduler = FakeScheduler()
+    client = DummyCalendarClient(events=[])
+    store = FakePlanningSessionStore(
+        sessions=[
+            _StoredSession(
+                user_id="U1",
+                planned_date=date(2025, 1, 1),
+                calendar_id="primary",
+                event_id="ffplanningu1",
+                status="planned",
+                source="admonisher_planning_card",
+                updated_at=datetime(2025, 1, 1, 8, 40, 0),
+            )
+        ]
+    )
+    reconciler = PlanningReconciler(
+        scheduler, calendar_client=client, planning_session_store=store
+    )
+
+    now = datetime(2025, 1, 1, 9, 0, tzinfo=timezone.utc)
+    jobs = await reconciler.reconcile_missing_planning(
+        scope="U1",
+        user_id="U1",
+        channel_id="C1",
+        now=now,
+    )
+
+    assert len(jobs) == 6
+    assert scheduler.get_jobs()


### PR DESCRIPTION
## Summary
Closes #87 by landing the reliability fixes that were validated in Slack + observability replay:

- reject cancelled events during post-upsert verification
- deterministic recreate path for cancelled pre-existing events
- update `planned_date` when `planning_session_refs` upsert matches `(calendar_id,event_id)`
- stale-anchor/reminder reconciliation hardening and branch diagnostics
- no-op terminal response for repeat NL commit on already-success planning draft
- AGENTS audit protocol update: restart bot before Slack audits and verify scrape/dependencies

## Validation
- `/Users/hugoevers/VScode-projects/admonish-1/.venv/bin/pytest -q tests/unit/test_planner_upsert_verification.py tests/unit/test_planning_session_store.py tests/unit/test_reconcile.py tests/unit/test_planning_reminder_suppression.py tests/unit/test_planning_add_to_calendar_flow.py tests/unit/test_event_draft_store.py`
- Result: `45 passed`

## Live audit notes
- Bot restarted before replay
- Prometheus healthy: `up{job="fateforger_app"} == 1`
- Slack thread replay (`D09A0RE9P7G` / `1772833072.504859`) confirms terminal response for repeat commit:
  - "This planning session is already on your calendar."
