### PR TITLE
Codex/issue-91-option3-session-constraints

### DIFF
--- a/.env.template
+++ b/.env.template
@@ -36,9 +36,9 @@ OPENAI_MODEL=gpt-4o-mini
 OPENAI_BASE_URL=
 
 # LLM Provider (OpenAI-compatible)
-# - openai: uses https://api.openai.com/v1 (default)
+# - openai: uses https://api.openai.com/v1
 # - openrouter: uses https://openrouter.ai/api/v1
-LLM_PROVIDER=openai
+LLM_PROVIDER=openrouter
 
 # OpenRouter Configuration (only used when LLM_PROVIDER=openrouter)
 OPENROUTER_API_KEY=or-your-openrouter-api-key-here
@@ -96,19 +96,23 @@ DEVELOPMENT=true
 SCHEDULER_TIMEZONE=UTC
 
 # Durable memory backend selection
-# - TIMEBOXING_MEMORY_BACKEND: constraint_mcp|mem0
-# - TASKS_DEFAULTS_MEMORY_BACKEND: constraint_mcp|mem0|disabled|inherit_timeboxing
-TIMEBOXING_MEMORY_BACKEND=constraint_mcp
-TASKS_DEFAULTS_MEMORY_BACKEND=constraint_mcp
+# Single durable memory backend (Graphiti only)
+TIMEBOXING_MEMORY_BACKEND=graphiti
+TASKS_DEFAULTS_MEMORY_BACKEND=graphiti
 # Optional fallback cache path when durable task defaults backend is unavailable.
 TASKS_DEFAULTS_CACHE_PATH=logs/taskmarshal_defaults_cache.json
 
-# Mem0 backend settings (required only when a selected backend is mem0)
-MEM0_USER_ID=timeboxing
-MEM0_IS_CLOUD=false
-MEM0_API_KEY=
-MEM0_LOCAL_CONFIG_JSON=
-MEM0_QUERY_LIMIT=200
+# Graphiti MCP backend settings (required when a selected backend is graphiti)
+GRAPHITI_USER_ID=timeboxing
+# Host-run app default. Docker compose overrides this inside the slack-bot container
+# to http://graphiti-mcp:8000/mcp.
+GRAPHITI_MCP_SERVER_URL=http://localhost:8005/mcp
+GRAPHITI_MCP_GROUP_ID=timeboxing
+GRAPHITI_MCP_TIMEOUT_SECONDS=15
+GRAPHITI_QUERY_LIMIT=200
+GRAPHITI_MCP_HOST_PORT=8005
+GRAPHITI_LLM_MODEL=google/gemini-3-flash-preview
+GRAPHITI_EMBEDDER_MODEL=openai/text-embedding-3-small
 
 # AutoGen event logging controls
 # summary|full|off

--- a/.gitignore
+++ b/.gitignore
@@ -238,3 +238,4 @@ data/*.db
 # Logs
 logs/
 *.log
+.worktrees/

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -71,6 +71,8 @@ services:
       # Single source of truth: define MCP_CALENDAR_SERVER_URL_DOCKER in `.env`
       # and pass it through to the app container as MCP_CALENDAR_SERVER_URL.
       MCP_CALENDAR_SERVER_URL: "${MCP_CALENDAR_SERVER_URL_DOCKER:?Set MCP_CALENDAR_SERVER_URL_DOCKER in .env}"
+      # Graphiti MCP is reachable via docker service name on the compose network.
+      GRAPHITI_MCP_SERVER_URL: "http://graphiti-mcp:8000/mcp"
     volumes:
       - app_data:/app/data
       - poetry-cache:/root/.cache/pypoetry
@@ -149,6 +151,23 @@ services:
     restart: "no"
     networks:
       - admonish-network
+
+  graphiti-mcp:
+    container_name: graphiti-mcp
+    image: zepai/knowledge-graph-mcp:latest
+    env_file: .env
+    environment:
+      # Graphiti uses an OpenAI-compatible client; route it via OpenRouter.
+      OPENAI_API_KEY: "${OPENROUTER_API_KEY:?Set OPENROUTER_API_KEY in .env for graphiti-mcp}"
+      OPENAI_API_URL: "${OPENROUTER_BASE_URL:-https://openrouter.ai/api/v1}"
+      LLM__MODEL: "${GRAPHITI_LLM_MODEL:-google/gemini-3-flash-preview}"
+      EMBEDDER__MODEL: "${GRAPHITI_EMBEDDER_MODEL:-openai/text-embedding-3-small}"
+    ports:
+      - "${GRAPHITI_MCP_HOST_PORT:-8005}:8000"
+    networks:
+      - admonish-network
+    restart: unless-stopped
+
   ticktick-mcp-auth:
     <<: *common
     profiles: ["ticktick", "auth"] # ← only runs when you ask for it

--- a/docs/plans/2026-03-08-timeboxing-session-constraint-override-design.md
+++ b/docs/plans/2026-03-08-timeboxing-session-constraint-override-design.md
@@ -1,0 +1,111 @@
+# Timeboxing Session Constraint Override Design
+
+## Goal
+
+Make same-day explicit session facts override conflicting profile/default memory, including conditional defaults such as "go to the gym unless another sport is already planned or explicitly stated for that day."
+
+## Problem
+
+The current Graphiti-backed baseline can canonicalize and filter durable constraints, but it still selects defaults too aggressively when same-day context should suppress them. In practice, a profile/default activity preference can remain active even after the user has stated a conflicting same-day activity or the calendar already anchors that day around another activity.
+
+## Design Summary
+
+Keep the fix inside the timeboxing memory-selection path. Reuse existing `hints.aspect_classification` metadata and teach stage-context reconciliation to evaluate conditional applicability before family-level selection.
+
+This keeps the planner from seeing avoidable noise and avoids introducing any new regex or substring heuristics. The storage model from `#81` remains intact; this is a selection-time precedence and suppression fix.
+
+## Existing Seams
+
+- `src/fateforger/agents/timeboxing/nlu.py`
+  - The interpreter prompt already defines:
+    - `is_conditional`
+    - `conditional_on_absent`
+    - `conditional_on_present`
+    - `excludes_aspect_ids`
+- `src/fateforger/agents/timeboxing/agent.py`
+  - `_collect_constraints()` computes:
+    - raw active constraints
+    - applicable active constraints
+    - selected active constraints
+  - `_reconcile_constraints_for_stage_context()` groups constraints into relevance families and currently picks a winner without evaluating cross-aspect suppression.
+  - `_collect_session_aspect_ids()` already extracts explicit same-session aspect IDs.
+- `src/fateforger/agents/timeboxing/constraint_reconciliation.py`
+  - Canonicalizes durable rows and applies date/stage applicability.
+  - Not the right place for session-only precedence logic.
+
+## Recommended Approach
+
+### 1. Build same-day aspect context
+
+Before family reconciliation, derive a set of active aspect IDs that represent stronger same-day facts. This set should include:
+
+- session-scoped constraint aspect IDs
+- aspect IDs from already applicable same-day constraints
+- explicit blockers surfaced through `excludes_aspect_ids`
+
+This context is only for the current turn/session and should not mutate stored durable records.
+
+### 2. Evaluate conditional applicability before reconciliation
+
+Add a conditional-applicability filter that checks `hints.aspect_classification`:
+
+- if `conditional_on_present` is non-empty, require one of those aspect IDs to be active
+- if `conditional_on_absent` is non-empty, suppress the candidate when any listed aspect ID is active
+- if `excludes_aspect_ids` overlaps the active aspect set, suppress the candidate unless the candidate itself is the stronger session-scoped fact
+
+This should happen before selecting one winner from a relevance family.
+
+### 3. Preserve family reconciliation, but only among eligible candidates
+
+Keep `_constraint_relevance_family_key()` and `_constraint_rank_for_stage_reconciliation()`, but apply them only to constraints that remain eligible after conditional suppression.
+
+If an entire family is suppressed, it should disappear from `session.active_constraints`.
+
+### 4. Make suppression observable
+
+Extend the existing `constraints_active_snapshot` debug event with deterministic fields:
+
+- `active_suppressed_count`
+- `active_suppressed_reasons`
+- optional preview of suppressed names/reasons for the first few candidates
+
+This preserves auditability without changing user-facing Slack copy in this ticket.
+
+## Ownership Boundaries
+
+- `agent.py`
+  - owns session-time precedence, suppression, and active-constraint selection
+- `constraint_reconciliation.py`
+  - continues to own durable-row canonicalization and basic day/stage applicability
+- `nlu.py`
+  - already defines the metadata contract; only prompt wording changes are needed if tests show coverage gaps
+
+## Non-goals
+
+- deduplicating dual extraction per Refine turn (`#104`)
+- Graphiti deployment/runtime DB audit (`#90`)
+- broader cross-agent memory redesign (`#64`)
+- changing durable storage schema or adding migrations
+
+## Testing Strategy
+
+Add targeted regressions around selection semantics:
+
+1. Session override
+- A session-scoped explicit activity beats a conflicting profile/default activity.
+
+2. Conditional suppression
+- A profile/default `gym_training` preference is suppressed when another same-day sport is explicit.
+
+3. Non-conflict preservation
+- The same gym preference remains eligible when no blocker exists.
+
+4. Observability
+- The session debug snapshot exposes suppression counts and reasons deterministically.
+
+## Risks
+
+- Over-suppressing constraints if family/category rules are too broad.
+- Hidden coupling between current family keys and the new active-aspect context.
+
+The mitigation is to keep the first pass narrow: drive suppression only from explicit `aspect_classification` metadata already present on candidates, and prove behavior with focused unit tests before broadening the model.

--- a/docs/plans/2026-03-08-timeboxing-session-constraint-override.md
+++ b/docs/plans/2026-03-08-timeboxing-session-constraint-override.md
@@ -1,0 +1,199 @@
+# Timeboxing Session Constraint Override Implementation Plan
+
+> **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
+
+**Goal:** Make same-day explicit session constraints suppress conflicting default/profile memory in the timeboxing agent.
+
+**Architecture:** Keep the fix in the timeboxing constraint-selection path. Reuse existing `aspect_classification` metadata to compute same-day active aspect context, suppress conditionally inapplicable defaults, then run the existing family-reconciliation ranking on the remaining candidates.
+
+**Tech Stack:** Python 3.11, pytest, SQLModel, Pydantic, AutoGen timeboxing agent
+
+---
+
+### Task 1: Add Failing Regressions For Session Override And Conditional Suppression
+
+**Files:**
+- Modify: `tests/unit/test_timeboxing_constraint_selection.py`
+- Reference: `src/fateforger/agents/timeboxing/agent.py`
+
+**Step 1: Write the failing tests**
+
+Add tests that cover:
+
+```python
+async def test_session_activity_overrides_conflicting_profile_default() -> None:
+    ...
+
+async def test_conditional_default_is_suppressed_by_same_day_activity() -> None:
+    ...
+
+async def test_conditional_default_remains_when_no_blocker_exists() -> None:
+    ...
+```
+
+Each test should build `Constraint` objects with `hints["aspect_classification"]` metadata and call `_collect_constraints()` or `_reconcile_constraints_for_stage_context()` through a minimal `TimeboxingFlowAgent` fixture pattern already used in this test module.
+
+**Step 2: Run test to verify it fails**
+
+Run: `poetry run pytest tests/unit/test_timeboxing_constraint_selection.py -q`
+
+Expected: FAIL on the new override/suppression assertions because current reconciliation does not honor conditional activity blockers.
+
+**Step 3: Write minimal implementation**
+
+Do not implement yet; move to Task 2.
+
+**Step 4: Run test to verify it still isolates the gap**
+
+Run: `poetry run pytest tests/unit/test_timeboxing_constraint_selection.py -q`
+
+Expected: the new tests fail and existing tests remain meaningful.
+
+**Step 5: Commit**
+
+Do not commit in this repo unless explicitly requested by the user.
+
+### Task 2: Implement Same-Day Conditional Suppression In Constraint Selection
+
+**Files:**
+- Modify: `src/fateforger/agents/timeboxing/agent.py`
+- Reference: `src/fateforger/agents/timeboxing/preferences.py`
+- Reference: `src/fateforger/agents/timeboxing/nlu.py`
+
+**Step 1: Add helper functions for active aspect context**
+
+Add focused helpers in `agent.py` for:
+
+```python
+def _constraint_excluded_aspect_ids(constraint: Constraint) -> set[str]:
+    ...
+
+def _constraint_conditional_present_ids(constraint: Constraint) -> set[str]:
+    ...
+
+def _constraint_conditional_absent_ids(constraint: Constraint) -> set[str]:
+    ...
+
+def _collect_active_aspect_ids(constraints: list[Constraint]) -> set[str]:
+    ...
+```
+
+These helpers should read only structured metadata from `hints["aspect_classification"]`.
+
+**Step 2: Apply conditional suppression before family reconciliation**
+
+Update `_reconcile_constraints_for_stage_context()` so it:
+
+```python
+active_aspect_ids = self._collect_active_aspect_ids(constraints)
+eligible, suppressed = self._suppress_conditionally_inapplicable_constraints(
+    session=session,
+    constraints=constraints,
+    active_aspect_ids=active_aspect_ids,
+)
+```
+
+Then reconcile `eligible` by family/rank.
+
+**Step 3: Preserve stronger session facts**
+
+Ensure session-scoped explicit constraints are not suppressed by weaker profile/default constraints. Scope precedence should remain:
+
+- `SESSION`
+- `DATESPAN`
+- `PROFILE`
+
+When a conflict exists, the lower-precedence candidate should be suppressed or lose reconciliation.
+
+**Step 4: Run targeted tests**
+
+Run: `poetry run pytest tests/unit/test_timeboxing_constraint_selection.py -q`
+
+Expected: PASS for the new regressions and the existing selection tests.
+
+**Step 5: Commit**
+
+Do not commit in this repo unless explicitly requested by the user.
+
+### Task 3: Add Deterministic Debug Evidence For Suppression
+
+**Files:**
+- Modify: `src/fateforger/agents/timeboxing/agent.py`
+- Test: `tests/unit/test_timeboxing_constraint_selection.py`
+
+**Step 1: Write the failing observability assertion**
+
+Add or extend a test asserting that the `constraints_active_snapshot` event contains suppression evidence, for example:
+
+```python
+assert snapshots[-1]["active_suppressed_count"] == 1
+assert snapshots[-1]["active_suppressed_reasons"] == ["excluded_by_aspect"]
+```
+
+**Step 2: Run test to verify it fails**
+
+Run: `poetry run pytest tests/unit/test_timeboxing_constraint_selection.py -q`
+
+Expected: FAIL because the snapshot does not yet expose suppression fields.
+
+**Step 3: Implement the minimal debug fields**
+
+Add deterministic suppression fields to `_collect_constraints()` / reconciliation helpers and keep values bounded and structured.
+
+**Step 4: Run test to verify it passes**
+
+Run: `poetry run pytest tests/unit/test_timeboxing_constraint_selection.py -q`
+
+Expected: PASS.
+
+**Step 5: Commit**
+
+Do not commit in this repo unless explicitly requested by the user.
+
+### Task 4: Run The Broader Targeted Validation Subset
+
+**Files:**
+- Test: `tests/unit/test_timeboxing_constraint_selection.py`
+- Test: `tests/unit/test_timeboxing_durable_constraints.py`
+- Test: `tests/unit/test_constraint_retriever.py`
+- Test: `tests/unit/test_timeboxing_memory_backend_selection.py`
+
+**Step 1: Run the focused regression suite**
+
+Run:
+
+```bash
+poetry run pytest \
+  tests/unit/test_timeboxing_constraint_selection.py \
+  tests/unit/test_timeboxing_durable_constraints.py \
+  tests/unit/test_constraint_retriever.py \
+  tests/unit/test_timeboxing_memory_backend_selection.py \
+  -q
+```
+
+Expected: PASS.
+
+**Step 2: Inspect for unintended behavioral drift**
+
+Review failures or changed assertions for:
+- active count semantics
+- durable stage prefetch behavior
+- Graphiti backend selection
+
+**Step 3: Update issue checkpoint**
+
+Post a progress checkpoint to issue `#91` with:
+- tests run
+- current status
+- remaining risks
+- `Open Items`
+
+**Step 4: Re-run cleanliness check**
+
+Run: `git status --porcelain`
+
+Expected: only intended files for `#91` are modified.
+
+**Step 5: Commit**
+
+Do not commit in this repo unless explicitly requested by the user.

--- a/docs/plans/2026-03-10-d2-story-viewer.md
+++ b/docs/plans/2026-03-10-d2-story-viewer.md
@@ -1,0 +1,1199 @@
+# d2-story-viewer Implementation Plan
+
+> **For agentic workers:** REQUIRED: Use superpowers:subagent-driven-development (if subagents available) or superpowers:executing-plans to implement this plan. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Build a self-contained npm package that turns a D2 diagram + a YAML narration sidecar into an interactive step-by-step story — as a browser-embeddable JS lib, and as a CLI that emits static HTML.
+
+**Architecture:** The viewer library (already exists as compiled JS in `logic-to-visual/prototype/`) is ported to TypeScript source in a new `logic-to-visual/package/` directory. A sidecar `.story.yaml` file holds all narration content; D2 files are never modified, but may optionally contain `# @step` comments that `d2story init` can extract to scaffold the sidecar. The CLI shells out to `d2` to render SVG, then inlines it into an HTML template with the viewer and narration embedded.
+
+**Tech Stack:** TypeScript, `js-yaml`, `commander`, `vitest`, `esbuild` (browser bundle), `tsc` (lib types)
+
+---
+
+## Chunk 1: Package scaffold + viewer TypeScript source
+
+### Task 1: Package scaffold
+
+**Files:**
+- Create: `logic-to-visual/package/package.json`
+- Create: `logic-to-visual/package/tsconfig.json`
+- Create: `logic-to-visual/package/.gitignore`
+
+- [ ] **Step 1: Create directory structure**
+
+```bash
+mkdir -p logic-to-visual/package/src/viewer
+mkdir -p logic-to-visual/package/src/story
+mkdir -p logic-to-visual/package/src/cli
+mkdir -p logic-to-visual/package/templates
+mkdir -p logic-to-visual/package/tests
+```
+
+- [ ] **Step 2: Write `package.json`**
+
+```json
+{
+  "name": "d2-story-viewer",
+  "version": "0.1.0",
+  "description": "Turn D2 diagrams into narrated interactive stories",
+  "type": "module",
+  "main": "./dist/viewer/index.js",
+  "types": "./dist/viewer/index.d.ts",
+  "exports": {
+    ".": {
+      "import": "./dist/viewer/index.js",
+      "types": "./dist/viewer/index.d.ts"
+    },
+    "./story": {
+      "import": "./dist/story/index.js",
+      "types": "./dist/story/index.d.ts"
+    }
+  },
+  "bin": {
+    "d2story": "./dist/cli/index.js"
+  },
+  "scripts": {
+    "build": "tsc && node esbuild.mjs",
+    "test": "vitest run",
+    "test:watch": "vitest"
+  },
+  "dependencies": {
+    "commander": "^12.0.0",
+    "js-yaml": "^4.1.0"
+  },
+  "devDependencies": {
+    "@types/js-yaml": "^4.0.9",
+    "@types/node": "^20.0.0",
+    "esbuild": "^0.21.0",
+    "typescript": "^5.4.0",
+    "vitest": "^1.5.0"
+  }
+}
+```
+
+- [ ] **Step 3: Write `tsconfig.json`**
+
+```json
+{
+  "compilerOptions": {
+    "target": "ES2020",
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext",
+    "outDir": "./dist",
+    "rootDir": "./src",
+    "strict": true,
+    "declaration": true,
+    "declarationMap": true,
+    "sourceMap": true,
+    "lib": ["ES2020", "DOM"]
+  },
+  "include": ["src/**/*"],
+  "exclude": ["node_modules", "dist", "tests"]
+}
+```
+
+- [ ] **Step 4: Write `esbuild.mjs`** (bundles viewer for browser `<script>` tag use)
+
+```js
+import * as esbuild from "esbuild";
+
+await esbuild.build({
+  entryPoints: ["src/viewer/index.ts"],
+  bundle: true,
+  format: "esm",
+  outfile: "dist/d2-story-viewer.bundle.js",
+  platform: "browser",
+});
+```
+
+- [ ] **Step 5: Write `.gitignore`**
+
+```
+node_modules/
+dist/
+```
+
+- [ ] **Step 6: Install deps**
+
+```bash
+cd logic-to-visual/package && npm install
+```
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add logic-to-visual/package/
+git commit -m "feat(d2-story-viewer): scaffold package"
+```
+
+---
+
+### Task 2: Viewer TypeScript source
+
+Port the existing compiled JS from `logic-to-visual/prototype/javascripts/d2-viewer/dist/` into TypeScript source. The compiled JS is the reference — read it before writing each file.
+
+**Files:**
+- Create: `logic-to-visual/package/src/viewer/types.ts`
+- Create: `logic-to-visual/package/src/viewer/utils.ts`
+- Create: `logic-to-visual/package/src/viewer/highlight.ts`
+- Create: `logic-to-visual/package/src/viewer/navigation.ts`
+- Create: `logic-to-visual/package/src/viewer/tagging.ts`
+- Create: `logic-to-visual/package/src/viewer/viewer.ts`
+- Create: `logic-to-visual/package/src/viewer/index.ts`
+
+- [ ] **Step 1: Write `types.ts`**
+
+```typescript
+export interface Step {
+  /** Short label shown in step pill UI, e.g. "01" */
+  tag?: string;
+  /** Headline shown in the narration panel */
+  title?: string;
+  /** Body text/HTML shown in the narration panel */
+  body?: string;
+  /** D2 node IDs to highlight in this step */
+  nodes?: string[];
+}
+
+export interface ViewerSelectors {
+  canvasWrap?: string;
+  svgHost?: string;
+  targetSvg?: string;
+  stepButtons?: string;
+  stepTag?: string;
+  stepTitle?: string;
+  stepBody?: string;
+  prevBtn?: string;
+  nextBtn?: string;
+  focusBtn?: string;
+  fitBtn?: string;
+  zoomInBtn?: string;
+  zoomOutBtn?: string;
+  detailDrawer?: string;
+  drawerNodeId?: string;
+  drawerBody?: string;
+  edgeTooltip?: string;
+}
+
+export interface ViewerOptions {
+  steps?: Step[];
+  /** All D2 node IDs present in the diagram */
+  nodeIds?: string[];
+  /** Map of nodeId → HTML string for click-to-expand detail drawer */
+  detailPanels?: Record<string, string>;
+  /** Map of edge label → HTML string for hover tooltip */
+  edgeTooltips?: Record<string, string>;
+  selectors?: ViewerSelectors;
+  contextNodeOpacity?: string;
+  contextEdgeOpacity?: string;
+  zoomFill?: number;
+  zoomFrames?: number;
+  panZoomMin?: number;
+  panZoomMax?: number;
+  panZoomOptions?: Record<string, unknown>;
+  exposeGlobals?: boolean;
+  autoBindControls?: boolean;
+  document?: Document;
+  /** svgPanZoom instance or compatible impl */
+  svgPanZoom?: (svg: SVGElement, options: Record<string, unknown>) => SvgPanZoom;
+}
+
+/** Minimal interface for svgPanZoom compatibility */
+export interface SvgPanZoom {
+  zoomIn(): void;
+  zoomOut(): void;
+  fit(): void;
+  center(): void;
+  resize(): void;
+  getZoom(): number;
+  getPan(): { x: number; y: number };
+  zoom(scale: number): void;
+  pan(point: { x: number; y: number }): void;
+  destroy?(): void;
+}
+```
+
+- [ ] **Step 2: Write `utils.ts`**
+
+```typescript
+export function b64(value: string): string {
+  return btoa(value);
+}
+
+export function decodeEdgeEndpointsFromClassToken(
+  token: string | undefined
+): [string, string] | null {
+  if (!token) return null;
+  let decoded = "";
+  try {
+    decoded = atob(token);
+  } catch {
+    return null;
+  }
+  decoded = decoded.replace(/&gt;/g, ">").trim().replace(/\[\d+\]$/, "");
+  let prefix = "";
+  const scoped = decoded.match(/^([a-zA-Z0-9_.]+)\.\((.+)\)$/);
+  if (scoped) {
+    prefix = scoped[1];
+    decoded = scoped[2];
+  } else if (decoded.startsWith("(") && decoded.endsWith(")")) {
+    decoded = decoded.slice(1, -1);
+  }
+  const parts = decoded.split("->").map((s) => s.trim());
+  if (parts.length !== 2 || !parts[0] || !parts[1]) return null;
+  const qualify = (part: string) =>
+    part.includes(".") || !prefix ? part : `${prefix}.${part}`;
+  return [qualify(parts[0]), qualify(parts[1])];
+}
+
+export function clamp(value: number, min: number, max: number): number {
+  return Math.max(min, Math.min(max, value));
+}
+```
+
+- [ ] **Step 3: Write `highlight.ts`** — copy logic from `prototype/.../highlight.js`, adding types. Key: `applyHighlight(viewer, nodeIds)` dims all non-active nodes/edges; `autoZoom(viewer, nodeIds)` pans+zooms to bounding box of active nodes with eased animation.
+
+- [ ] **Step 4: Write `navigation.ts`** — copy logic from `prototype/.../navigation.js`, adding types. Key exports: `goStep`, `toggleFocus`, `resetOverview`, `bindKeyboard`.
+
+- [ ] **Step 5: Write `tagging.ts`** — copy logic from `prototype/.../tagging.js`, adding types. Key: `tagNodes` adds `.d2-node` + click handler; `tagEdges` adds `.d2-edge` + src/dst data attrs; `setupEdgeTooltips` wires hover.
+
+- [ ] **Step 6: Write `viewer.ts`** — copy the `D2StoryViewer` class from `prototype/.../viewer.js`, adding types from `types.ts`.
+
+- [ ] **Step 7: Write `index.ts`**
+
+```typescript
+export { D2StoryViewer } from "./viewer.js";
+export type { Step, ViewerOptions, ViewerSelectors, SvgPanZoom } from "./types.js";
+```
+
+- [ ] **Step 8: Build to verify no TS errors**
+
+```bash
+cd logic-to-visual/package && npm run build
+```
+
+Expected: `dist/viewer/` populated, no errors.
+
+- [ ] **Step 9: Commit**
+
+```bash
+git add logic-to-visual/package/src/viewer/
+git commit -m "feat(d2-story-viewer): port viewer to TypeScript source"
+```
+
+---
+
+## Chunk 2: Story format — types, parser, D2 comment extractor
+
+### Task 3: Story format types + YAML schema
+
+**Files:**
+- Create: `logic-to-visual/package/src/story/types.ts`
+- Create: `logic-to-visual/package/docs/story-format.md`
+
+- [ ] **Step 1: Write `src/story/types.ts`**
+
+```typescript
+/**
+ * Root structure of a .story.yaml narration file.
+ *
+ * LLM PATCH NOTES:
+ * - To add a step: append to `steps[]`, set `id`, `title`, `nodes`.
+ * - To edit narration: update `title` or `body` in the relevant step.
+ * - To add a detail panel: add entry to `detail_panels` keyed by D2 node ID.
+ * - `nodes` values MUST match D2 source node names exactly (case-sensitive).
+ * - Nested D2 nodes use dot notation: "System.Client"
+ */
+export interface StoryFile {
+  meta?: StoryMeta;
+  steps: StoryStep[];
+  detail_panels?: Record<string, string>;
+  edge_tooltips?: Record<string, string>;
+}
+
+export interface StoryMeta {
+  title?: string;
+  description?: string;
+  /** Path to the .d2 source file, relative to this .story.yaml */
+  d2_source?: string;
+}
+
+export interface StoryStep {
+  /**
+   * Stable identifier — used to match against `# @step <id>` comments in .d2.
+   * Snake-case recommended. Example: "step-01"
+   */
+  id: string;
+  /** Short label shown in step pill UI. Example: "01" */
+  tag?: string;
+  /** Headline for this step */
+  title: string;
+  /** Body text or HTML rendered in the narration panel */
+  body?: string;
+  /**
+   * D2 node IDs to highlight.
+   * Must match node names in the .d2 file exactly.
+   * Use dot notation for nested nodes: "Container.Child"
+   */
+  nodes?: string[];
+}
+```
+
+- [ ] **Step 2: Write `docs/story-format.md`**
+
+```markdown
+# Story Format Reference
+
+A `.story.yaml` file narrates a D2 diagram. It lives next to the `.d2` file
+and is the single source of truth for step content. The `.d2` file is never
+modified.
+
+## Minimal example
+
+\`\`\`yaml
+# my-diagram.story.yaml
+meta:
+  title: "Request Flow"
+  d2_source: my-diagram.d2
+
+steps:
+  - id: step-01
+    tag: "01"
+    title: "Client sends request"
+    body: |
+      The client initiates an HTTP POST to /api/data.
+      Authentication is handled at this boundary.
+    nodes:
+      - Client
+      - Server
+
+  - id: step-02
+    tag: "02"
+    title: "Server queries database"
+    nodes:
+      - Server
+      - Database
+\`\`\`
+
+## Linking to D2 nodes
+
+`nodes` values must match D2 node names exactly (case-sensitive).
+
+| D2 source | `nodes` value |
+|-----------|---------------|
+| `Client`  | `Client`      |
+| `System.Client` | `System.Client` |
+| `"My Service"` | `My Service` |
+
+## Optional: D2 comment annotations
+
+You can annotate your `.d2` file with `# @step <id>` comments.
+These are ignored by the D2 renderer — they only help `d2story init`
+scaffold the sidecar automatically.
+
+\`\`\`d2
+# @step step-01
+Client -> Server: POST /api/data
+
+# @step step-02
+Server -> Database: SELECT ...
+\`\`\`
+
+Running `d2story init my-diagram.d2` will produce a starter `my-diagram.story.yaml`
+with the annotated steps pre-populated.
+
+## Detail panels
+
+Click-to-expand node details. Keys are D2 node IDs; values are HTML.
+
+\`\`\`yaml
+detail_panels:
+  Server: |
+    <p>Handles authentication and request routing.</p>
+    <ul><li>Rate limited: 1000 req/s</li></ul>
+\`\`\`
+
+## Edge tooltips
+
+Hover tooltips on edges. Keys are the edge label text from D2.
+
+\`\`\`yaml
+edge_tooltips:
+  "POST /api/data": "Authenticated with Bearer token"
+\`\`\`
+
+## LLM patching guide
+
+When an LLM modifies this file:
+- Add steps by appending to `steps[]` with a new unique `id`
+- Node IDs come from the `.d2` file — never invent them
+- `body` supports inline HTML; use `|` block scalar for multi-line
+- Preserve existing `id` values — they may be referenced by `# @step` annotations
+- Run `d2story build` after changes to verify node IDs are valid
+```
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add logic-to-visual/package/src/story/types.ts logic-to-visual/package/docs/
+git commit -m "feat(d2-story-viewer): story format types and docs"
+```
+
+---
+
+### Task 4: YAML parser
+
+**Files:**
+- Create: `logic-to-visual/package/src/story/parser.ts`
+- Create: `logic-to-visual/package/tests/story-parser.test.ts`
+
+- [ ] **Step 1: Write the failing test**
+
+```typescript
+// tests/story-parser.test.ts
+import { describe, it, expect } from "vitest";
+import { parseStoryFile } from "../src/story/parser.js";
+
+describe("parseStoryFile", () => {
+  it("parses a minimal valid story", () => {
+    const yaml = `
+steps:
+  - id: step-01
+    title: "Client sends request"
+    nodes: [Client, Server]
+`;
+    const result = parseStoryFile(yaml);
+    expect(result.steps).toHaveLength(1);
+    expect(result.steps[0].id).toBe("step-01");
+    expect(result.steps[0].nodes).toEqual(["Client", "Server"]);
+  });
+
+  it("throws on missing steps key", () => {
+    expect(() => parseStoryFile("meta:\n  title: foo")).toThrow(/steps/);
+  });
+
+  it("throws on step missing id", () => {
+    const yaml = `steps:\n  - title: "No ID"`;
+    expect(() => parseStoryFile(yaml)).toThrow(/id/);
+  });
+
+  it("parses detail_panels and edge_tooltips", () => {
+    const yaml = `
+steps:
+  - id: s1
+    title: T
+detail_panels:
+  Server: "<p>info</p>"
+edge_tooltips:
+  "sends to": "HTTP POST"
+`;
+    const result = parseStoryFile(yaml);
+    expect(result.detail_panels?.Server).toBe("<p>info</p>");
+    expect(result.edge_tooltips?.["sends to"]).toBe("HTTP POST");
+  });
+});
+```
+
+- [ ] **Step 2: Run test — expect FAIL**
+
+```bash
+cd logic-to-visual/package && npm test -- tests/story-parser.test.ts
+```
+
+Expected: FAIL with "Cannot find module"
+
+- [ ] **Step 3: Write `src/story/parser.ts`**
+
+```typescript
+import yaml from "js-yaml";
+import type { StoryFile, StoryStep } from "./types.js";
+
+export function parseStoryFile(content: string): StoryFile {
+  const raw = yaml.load(content) as Record<string, unknown>;
+
+  if (!raw || typeof raw !== "object") {
+    throw new Error("Story file must be a YAML object");
+  }
+  if (!Array.isArray(raw.steps)) {
+    throw new Error("Story file must have a 'steps' array");
+  }
+
+  const steps: StoryStep[] = raw.steps.map((s: unknown, i: number) => {
+    if (!s || typeof s !== "object") {
+      throw new Error(`Step ${i} is not an object`);
+    }
+    const step = s as Record<string, unknown>;
+    if (typeof step.id !== "string" || !step.id) {
+      throw new Error(`Step ${i} is missing required field 'id'`);
+    }
+    if (typeof step.title !== "string" || !step.title) {
+      throw new Error(`Step ${i} (id: ${step.id}) is missing required field 'title'`);
+    }
+    return {
+      id: step.id,
+      tag: typeof step.tag === "string" ? step.tag : undefined,
+      title: step.title,
+      body: typeof step.body === "string" ? step.body : undefined,
+      nodes: Array.isArray(step.nodes)
+        ? step.nodes.map((n) => String(n))
+        : undefined,
+    };
+  });
+
+  return {
+    meta: typeof raw.meta === "object" && raw.meta !== null
+      ? (raw.meta as StoryFile["meta"])
+      : undefined,
+    steps,
+    detail_panels:
+      typeof raw.detail_panels === "object" && raw.detail_panels !== null
+        ? (raw.detail_panels as Record<string, string>)
+        : undefined,
+    edge_tooltips:
+      typeof raw.edge_tooltips === "object" && raw.edge_tooltips !== null
+        ? (raw.edge_tooltips as Record<string, string>)
+        : undefined,
+  };
+}
+```
+
+- [ ] **Step 4: Run test — expect PASS**
+
+```bash
+cd logic-to-visual/package && npm test -- tests/story-parser.test.ts
+```
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add logic-to-visual/package/src/story/parser.ts logic-to-visual/package/tests/story-parser.test.ts
+git commit -m "feat(d2-story-viewer): YAML story parser with validation"
+```
+
+---
+
+### Task 5: D2 comment extractor
+
+Parses `# @step <id>` annotations from `.d2` source and extracts which node names follow each annotation. This powers `d2story init`.
+
+**Files:**
+- Create: `logic-to-visual/package/src/story/d2-extractor.ts`
+- Create: `logic-to-visual/package/tests/d2-extractor.test.ts`
+
+The `# @step <id>` comment must appear on the line immediately before a node declaration or edge. The extractor collects the node/connection names that follow until the next `@step` or end of file.
+
+Node names in D2 are everything before `:`, `->`, `{`, or end-of-line (trimmed).
+
+- [ ] **Step 1: Write the failing test**
+
+```typescript
+// tests/d2-extractor.test.ts
+import { describe, it, expect } from "vitest";
+import { extractStepsFromD2 } from "../src/story/d2-extractor.js";
+
+describe("extractStepsFromD2", () => {
+  it("extracts nodes following @step annotation", () => {
+    const d2 = `
+# @step step-01
+Client -> Server: sends to
+# @step step-02
+Server -> Database: queries
+`;
+    const steps = extractStepsFromD2(d2);
+    expect(steps).toHaveLength(2);
+    expect(steps[0].id).toBe("step-01");
+    expect(steps[0].nodes).toContain("Client");
+    expect(steps[0].nodes).toContain("Server");
+    expect(steps[1].id).toBe("step-02");
+    expect(steps[1].nodes).toContain("Server");
+    expect(steps[1].nodes).toContain("Database");
+  });
+
+  it("returns empty array when no @step annotations", () => {
+    expect(extractStepsFromD2("Client -> Server")).toHaveLength(0);
+  });
+
+  it("ignores non-@step comments", () => {
+    const d2 = `
+# just a regular comment
+# @step step-01
+Client -> Server
+`;
+    const steps = extractStepsFromD2(d2);
+    expect(steps).toHaveLength(1);
+  });
+
+  it("handles nested node names", () => {
+    const d2 = `
+# @step step-01
+System.Client -> System.Server: req
+`;
+    const steps = extractStepsFromD2(d2);
+    expect(steps[0].nodes).toContain("System.Client");
+    expect(steps[0].nodes).toContain("System.Server");
+  });
+});
+```
+
+- [ ] **Step 2: Run test — expect FAIL**
+
+- [ ] **Step 3: Write `src/story/d2-extractor.ts`**
+
+```typescript
+import type { StoryStep } from "./types.js";
+
+const STEP_ANNOTATION = /^#\s*@step\s+(\S+)/;
+const EDGE_LINE = /^([A-Za-z0-9_."' ]+?)\s*->\s*([A-Za-z0-9_."' ]+?)(?:\s*:|$|\s*\{)/;
+const NODE_LINE = /^([A-Za-z0-9_."' ]+?)(?:\s*:|$|\s*\{)/;
+const SKIP_LINE = /^\s*(#|$|\})/;
+
+function parseNodesFromLine(line: string): string[] {
+  const edge = EDGE_LINE.exec(line.trim());
+  if (edge) return [edge[1].trim(), edge[2].trim()];
+  if (SKIP_LINE.test(line.trim())) return [];
+  const node = NODE_LINE.exec(line.trim());
+  if (node) return [node[1].trim()];
+  return [];
+}
+
+export function extractStepsFromD2(d2Source: string): StoryStep[] {
+  const lines = d2Source.split("\n");
+  const steps: StoryStep[] = [];
+  let current: StoryStep | null = null;
+
+  for (const line of lines) {
+    const annotationMatch = STEP_ANNOTATION.exec(line);
+    if (annotationMatch) {
+      if (current) steps.push(current);
+      current = { id: annotationMatch[1], title: annotationMatch[1], nodes: [] };
+      continue;
+    }
+    if (current) {
+      const nodes = parseNodesFromLine(line);
+      for (const n of nodes) {
+        if (!current.nodes!.includes(n)) current.nodes!.push(n);
+      }
+    }
+  }
+  if (current) steps.push(current);
+  return steps;
+}
+```
+
+- [ ] **Step 4: Run test — expect PASS**
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add logic-to-visual/package/src/story/d2-extractor.ts logic-to-visual/package/tests/d2-extractor.test.ts
+git commit -m "feat(d2-story-viewer): D2 comment extractor for @step annotations"
+```
+
+---
+
+### Task 6: Story index + story-to-viewer adapter
+
+Bridge between `StoryFile` (YAML format) and `ViewerOptions` (what the viewer constructor needs).
+
+**Files:**
+- Create: `logic-to-visual/package/src/story/adapter.ts`
+- Create: `logic-to-visual/package/src/story/index.ts`
+- Create: `logic-to-visual/package/tests/adapter.test.ts`
+
+- [ ] **Step 1: Write failing test**
+
+```typescript
+// tests/adapter.test.ts
+import { describe, it, expect } from "vitest";
+import { storyToViewerOptions } from "../src/story/adapter.js";
+import type { StoryFile } from "../src/story/types.js";
+
+describe("storyToViewerOptions", () => {
+  it("maps steps to viewer steps", () => {
+    const story: StoryFile = {
+      steps: [
+        { id: "s1", title: "Step 1", nodes: ["A", "B"], tag: "01", body: "hello" },
+      ],
+    };
+    const opts = storyToViewerOptions(story);
+    expect(opts.steps![0]).toMatchObject({ tag: "01", title: "Step 1", body: "hello", nodes: ["A", "B"] });
+  });
+
+  it("collects all unique nodeIds from all steps", () => {
+    const story: StoryFile = {
+      steps: [
+        { id: "s1", title: "T1", nodes: ["A", "B"] },
+        { id: "s2", title: "T2", nodes: ["B", "C"] },
+      ],
+    };
+    const opts = storyToViewerOptions(story);
+    expect(opts.nodeIds).toEqual(expect.arrayContaining(["A", "B", "C"]));
+    expect(opts.nodeIds).toHaveLength(3);
+  });
+
+  it("passes through detail_panels and edge_tooltips", () => {
+    const story: StoryFile = {
+      steps: [{ id: "s1", title: "T" }],
+      detail_panels: { X: "<p>x</p>" },
+      edge_tooltips: { "foo": "bar" },
+    };
+    const opts = storyToViewerOptions(story);
+    expect(opts.detailPanels?.X).toBe("<p>x</p>");
+    expect(opts.edgeTooltips?.foo).toBe("bar");
+  });
+});
+```
+
+- [ ] **Step 2: Run test — expect FAIL**
+
+- [ ] **Step 3: Write `src/story/adapter.ts`**
+
+```typescript
+import type { StoryFile } from "./types.js";
+import type { ViewerOptions } from "../viewer/types.js";
+
+export function storyToViewerOptions(story: StoryFile): ViewerOptions {
+  const nodeIdSet = new Set<string>();
+  for (const step of story.steps) {
+    for (const n of step.nodes ?? []) nodeIdSet.add(n);
+  }
+  return {
+    steps: story.steps.map((s) => ({
+      tag: s.tag,
+      title: s.title,
+      body: s.body,
+      nodes: s.nodes,
+    })),
+    nodeIds: Array.from(nodeIdSet),
+    detailPanels: story.detail_panels,
+    edgeTooltips: story.edge_tooltips,
+  };
+}
+```
+
+- [ ] **Step 4: Write `src/story/index.ts`**
+
+```typescript
+export { parseStoryFile } from "./parser.js";
+export { extractStepsFromD2 } from "./d2-extractor.js";
+export { storyToViewerOptions } from "./adapter.js";
+export type { StoryFile, StoryStep, StoryMeta } from "./types.js";
+```
+
+- [ ] **Step 5: Run test — expect PASS**
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add logic-to-visual/package/src/story/ logic-to-visual/package/tests/adapter.test.ts
+git commit -m "feat(d2-story-viewer): story-to-viewer adapter"
+```
+
+---
+
+## Chunk 3: CLI — `d2story init` and `d2story build`
+
+### Task 7: HTML template
+
+The template is a self-contained HTML file with placeholders for inlined SVG and viewer config.
+
+**Files:**
+- Create: `logic-to-visual/package/templates/story.html`
+
+- [ ] **Step 1: Write `templates/story.html`**
+
+The template uses `{{SVG_CONTENT}}` and `{{VIEWER_CONFIG_JSON}}` as injection points.
+
+```html
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>{{META_TITLE}}</title>
+  <style>
+    *, *::before, *::after { box-sizing: border-box; margin: 0; padding: 0; }
+    body { display: flex; height: 100vh; font-family: system-ui, sans-serif; background: #0f1117; color: #e2e8f0; }
+    #canvas-wrap { flex: 1; position: relative; overflow: hidden; }
+    #svg-host { width: 100%; height: 100%; }
+    #svg-host svg { display: block; }
+    #panel { width: 320px; display: flex; flex-direction: column; border-left: 1px solid #2d3748; background: #161b27; }
+    #step-nav { display: flex; flex-wrap: wrap; gap: 4px; padding: 12px; border-bottom: 1px solid #2d3748; }
+    .step-btn { padding: 4px 10px; border-radius: 4px; border: 1px solid #4a5568; background: transparent; color: #a0aec0; cursor: pointer; font-size: 12px; }
+    .step-btn.active { background: #3182ce; border-color: #3182ce; color: #fff; }
+    #step-content { flex: 1; overflow-y: auto; padding: 16px; }
+    #step-tag { font-size: 11px; text-transform: uppercase; letter-spacing: 0.08em; color: #4a90d9; margin-bottom: 6px; }
+    #step-title { font-size: 15px; font-weight: 600; margin-bottom: 10px; }
+    #step-body { font-size: 13px; color: #a0aec0; line-height: 1.6; }
+    #toolbar { display: flex; gap: 6px; padding: 10px 12px; border-top: 1px solid #2d3748; }
+    #toolbar button { flex: 1; padding: 5px 0; border-radius: 4px; border: 1px solid #4a5568; background: transparent; color: #a0aec0; cursor: pointer; font-size: 11px; }
+    #toolbar button:hover { background: #2d3748; }
+    #detail-drawer { position: absolute; right: 0; top: 0; width: 280px; height: 100%; background: #1a202c; border-left: 1px solid #2d3748; padding: 16px; transform: translateX(100%); transition: transform 0.2s; overflow-y: auto; z-index: 10; }
+    #detail-drawer.open { transform: translateX(0); }
+    #drawer-node-id { font-size: 11px; color: #4a90d9; margin-bottom: 8px; font-family: monospace; }
+    #edge-tooltip { position: fixed; background: #2d3748; border: 1px solid #4a5568; border-radius: 4px; padding: 6px 10px; font-size: 12px; pointer-events: none; opacity: 0; transition: opacity 0.1s; max-width: 280px; z-index: 100; }
+    #edge-tooltip.visible { opacity: 1; }
+    .focus-mode .d2-node.dimmed { display: none; }
+    .focus-mode .d2-edge.dimmed { display: none; }
+  </style>
+</head>
+<body>
+  <div id="canvas-wrap">
+    <div id="svg-host">{{SVG_CONTENT}}</div>
+    <div id="detail-drawer">
+      <div id="drawer-node-id"></div>
+      <div id="drawer-body"></div>
+    </div>
+  </div>
+  <div id="panel">
+    <div id="step-nav">{{STEP_BUTTONS}}</div>
+    <div id="step-content">
+      <div id="step-tag"></div>
+      <div id="step-title"></div>
+      <div id="step-body"></div>
+    </div>
+    <div id="toolbar">
+      <button id="btn-prev">← Prev</button>
+      <button id="btn-next">Next →</button>
+      <button id="btn-focus" title="Toggle focus mode">● Focus</button>
+      <button id="btn-fit">Fit</button>
+    </div>
+  </div>
+  <div id="edge-tooltip"></div>
+
+  <script src="https://cdn.jsdelivr.net/npm/svg-pan-zoom@3.6.1/dist/svg-pan-zoom.min.js"></script>
+  <script type="module">
+    import { D2StoryViewer } from "{{VIEWER_BUNDLE_PATH}}";
+    const config = {{VIEWER_CONFIG_JSON}};
+    const viewer = new D2StoryViewer({ ...config, autoBindControls: true });
+    viewer.init();
+  </script>
+</body>
+</html>
+```
+
+**Note:** For the fully self-contained `--inline` mode, `{{VIEWER_BUNDLE_PATH}}` is replaced with an inline `<script>` tag containing the bundled viewer JS, and the svgPanZoom CDN link is replaced with an inlined copy.
+
+- [ ] **Step 2: Commit**
+
+```bash
+git add logic-to-visual/package/templates/
+git commit -m "feat(d2-story-viewer): HTML story template"
+```
+
+---
+
+### Task 8: HTML builder
+
+Assembles the template with real content.
+
+**Files:**
+- Create: `logic-to-visual/package/src/cli/builder.ts`
+- Create: `logic-to-visual/package/tests/builder.test.ts`
+
+- [ ] **Step 1: Write failing test**
+
+```typescript
+// tests/builder.test.ts
+import { describe, it, expect } from "vitest";
+import { buildHtml } from "../src/cli/builder.js";
+import type { StoryFile } from "../src/story/types.js";
+
+const story: StoryFile = {
+  meta: { title: "Test Story" },
+  steps: [{ id: "s1", tag: "01", title: "First step", nodes: ["A"] }],
+};
+
+describe("buildHtml", () => {
+  it("inlines SVG content", () => {
+    const html = buildHtml("<svg><g id='A'/></svg>", story, { viewerBundlePath: "./d2-story-viewer.bundle.js" });
+    expect(html).toContain("<svg>");
+  });
+
+  it("sets page title from meta", () => {
+    const html = buildHtml("<svg/>", story, { viewerBundlePath: "./x.js" });
+    expect(html).toContain("<title>Test Story</title>");
+  });
+
+  it("injects step buttons", () => {
+    const html = buildHtml("<svg/>", story, { viewerBundlePath: "./x.js" });
+    expect(html).toContain('data-step="0"');
+    expect(html).toContain("01");
+  });
+
+  it("injects viewer config JSON", () => {
+    const html = buildHtml("<svg/>", story, { viewerBundlePath: "./x.js" });
+    const configMatch = html.match(/const config = ({.*?});/s);
+    expect(configMatch).toBeTruthy();
+    const config = JSON.parse(configMatch![1]);
+    expect(config.steps[0].title).toBe("First step");
+    expect(config.nodeIds).toContain("A");
+  });
+});
+```
+
+- [ ] **Step 2: Run test — expect FAIL**
+
+- [ ] **Step 3: Write `src/cli/builder.ts`**
+
+```typescript
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import { join, dirname } from "node:path";
+import { storyToViewerOptions } from "../story/adapter.js";
+import type { StoryFile } from "../story/types.js";
+
+const __dir = dirname(fileURLToPath(import.meta.url));
+const TEMPLATE_PATH = join(__dir, "../../templates/story.html");
+
+export interface BuildOptions {
+  viewerBundlePath: string;
+}
+
+export function buildHtml(
+  svgContent: string,
+  story: StoryFile,
+  options: BuildOptions
+): string {
+  const template = readFileSync(TEMPLATE_PATH, "utf8");
+  const viewerOptions = storyToViewerOptions(story);
+  const title = story.meta?.title ?? "D2 Story";
+
+  const stepButtons = viewerOptions.steps!
+    .map(
+      (s, i) =>
+        `<button class="step-btn" data-step="${i}">${s.tag ?? String(i + 1)}</button>`
+    )
+    .join("\n");
+
+  return template
+    .replace("{{META_TITLE}}", escapeHtml(title))
+    .replace("{{SVG_CONTENT}}", svgContent)
+    .replace("{{STEP_BUTTONS}}", stepButtons)
+    .replace("{{VIEWER_BUNDLE_PATH}}", options.viewerBundlePath)
+    .replace("{{VIEWER_CONFIG_JSON}}", JSON.stringify(viewerOptions, null, 2));
+}
+
+function escapeHtml(s: string): string {
+  return s.replace(/&/g, "&amp;").replace(/</g, "&lt;").replace(/>/g, "&gt;");
+}
+```
+
+- [ ] **Step 4: Run test — expect PASS**
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add logic-to-visual/package/src/cli/builder.ts logic-to-visual/package/tests/builder.test.ts
+git commit -m "feat(d2-story-viewer): HTML builder"
+```
+
+---
+
+### Task 9: CLI entry — `d2story build` and `d2story init`
+
+**Files:**
+- Create: `logic-to-visual/package/src/cli/index.ts`
+
+- [ ] **Step 1: Write `src/cli/index.ts`**
+
+```typescript
+#!/usr/bin/env node
+import { Command } from "commander";
+import { execSync } from "node:child_process";
+import { readFileSync, writeFileSync } from "node:fs";
+import { resolve, dirname, basename, extname } from "node:path";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { parseStoryFile } from "../story/parser.js";
+import { extractStepsFromD2 } from "../story/d2-extractor.js";
+import { buildHtml } from "./builder.js";
+
+const program = new Command();
+program.name("d2story").description("D2 diagram story tools").version("0.1.0");
+
+// ── build ─────────────────────────────────────────────────────────────────────
+program
+  .command("build <diagram.d2> <story.yaml>")
+  .description("Render a D2 diagram + story sidecar into a self-contained HTML file")
+  .option("-o, --out <file>", "Output HTML file (default: <story-basename>.html)")
+  .option("--viewer-bundle <path>", "Path to viewer bundle JS (default: CDN)", "")
+  .action(async (d2Path: string, storyPath: string, opts: { out?: string; viewerBundle?: string }) => {
+    const d2Abs = resolve(d2Path);
+    const storyAbs = resolve(storyPath);
+
+    // Render D2 → SVG via CLI
+    const svgTmp = join(tmpdir(), `d2story-${Date.now()}.svg`);
+    try {
+      execSync(`d2 "${d2Abs}" "${svgTmp}"`, { stdio: "pipe" });
+    } catch (e) {
+      console.error("d2 render failed:", (e as Error).message);
+      process.exit(1);
+    }
+    const svgContent = readFileSync(svgTmp, "utf8");
+
+    // Parse story
+    const storyContent = readFileSync(storyAbs, "utf8");
+    const story = parseStoryFile(storyContent);
+
+    // Validate node IDs exist in SVG
+    validateNodeIds(story, svgContent);
+
+    // Build HTML
+    const viewerBundlePath = opts.viewerBundle || "https://cdn.jsdelivr.net/npm/d2-story-viewer/dist/d2-story-viewer.bundle.js";
+    const html = buildHtml(svgContent, story, { viewerBundlePath });
+
+    const outPath = opts.out ?? resolve(dirname(storyAbs), basename(storyAbs, extname(storyAbs)) + ".html");
+    writeFileSync(outPath, html, "utf8");
+    console.log(`✓ Written to ${outPath}`);
+  });
+
+// ── init ──────────────────────────────────────────────────────────────────────
+program
+  .command("init <diagram.d2>")
+  .description("Scaffold a .story.yaml from @step annotations in a D2 file")
+  .option("-o, --out <file>", "Output story file (default: <diagram>.story.yaml)")
+  .action((d2Path: string, opts: { out?: string }) => {
+    const d2Abs = resolve(d2Path);
+    const d2Source = readFileSync(d2Abs, "utf8");
+    const extracted = extractStepsFromD2(d2Source);
+
+    const outPath =
+      opts.out ??
+      resolve(dirname(d2Abs), basename(d2Abs, extname(d2Abs)) + ".story.yaml");
+
+    const yamlLines = [
+      `# Auto-generated by d2story init — edit titles and body text`,
+      `# Node IDs must match D2 source names exactly.`,
+      `# See: https://github.com/your-org/d2-story-viewer/docs/story-format.md`,
+      ``,
+      `meta:`,
+      `  title: "${basename(d2Abs, extname(d2Abs))}"`,
+      `  d2_source: ${basename(d2Abs)}`,
+      ``,
+      `steps:`,
+    ];
+
+    if (extracted.length === 0) {
+      yamlLines.push(
+        `  # No @step annotations found in ${basename(d2Abs)}.`,
+        `  # Add  # @step <id>  comments above nodes/edges in your .d2 file,`,
+        `  # or write steps manually following the format below.`,
+        `  - id: step-01`,
+        `    tag: "01"`,
+        `    title: "TODO: describe this step"`,
+        `    nodes: []  # TODO: add D2 node names`,
+      );
+    } else {
+      for (const step of extracted) {
+        yamlLines.push(
+          `  - id: ${step.id}`,
+          `    tag: "${step.id}"`,
+          `    title: "TODO: describe ${step.id}"`,
+          `    body: ""`,
+          `    nodes:`,
+          ...(step.nodes ?? []).map((n) => `      - ${n}`),
+          ``,
+        );
+      }
+    }
+
+    writeFileSync(outPath, yamlLines.join("\n"), "utf8");
+    console.log(`✓ Story scaffold written to ${outPath}`);
+    if (extracted.length > 0) {
+      console.log(`  Found ${extracted.length} @step annotation(s). Edit titles and body text.`);
+    } else {
+      console.log(`  No @step annotations found — scaffold written with placeholder step.`);
+      console.log(`  Tip: add  # @step <id>  comments above nodes/edges in ${basename(d2Abs)}`);
+    }
+  });
+
+program.parse();
+
+// ── helpers ───────────────────────────────────────────────────────────────────
+function validateNodeIds(story: ReturnType<typeof parseStoryFile>, svgContent: string): void {
+  const allNodes = story.steps.flatMap((s) => s.nodes ?? []);
+  const missing: string[] = [];
+  for (const nodeId of allNodes) {
+    const cls = btoa(nodeId);
+    if (!svgContent.includes(cls)) {
+      missing.push(nodeId);
+    }
+  }
+  if (missing.length > 0) {
+    console.warn(`⚠ Node IDs not found in rendered SVG (check D2 names match exactly):`);
+    for (const m of missing) console.warn(`  - ${m}`);
+  }
+}
+```
+
+- [ ] **Step 2: Build**
+
+```bash
+cd logic-to-visual/package && npm run build
+```
+
+- [ ] **Step 3: Smoke test `d2story init`**
+
+Use the existing `.d2` file in the repo:
+```bash
+node dist/cli/index.js init ../../docs/architecture/constraint-flow.d2
+```
+
+Expected: prints path to scaffold file, no crash.
+
+- [ ] **Step 4: Smoke test `d2story build`**
+
+Requires a `.story.yaml` to exist (create a minimal one or use the scaffold):
+```bash
+node dist/cli/index.js build ../../docs/architecture/constraint-flow.d2 constraint-flow.story.yaml -o /tmp/story-test.html
+open /tmp/story-test.html
+```
+
+Expected: HTML file opens in browser with the diagram and step panel visible.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add logic-to-visual/package/src/cli/
+git commit -m "feat(d2-story-viewer): CLI — d2story build and d2story init"
+```
+
+---
+
+## Chunk 4: README + polish
+
+### Task 10: README
+
+**Files:**
+- Create: `logic-to-visual/package/README.md`
+
+- [ ] **Step 1: Write README covering:**
+  - What it is (1 para)
+  - Quick start: install, `d2story init`, `d2story build`
+  - Story format quick reference (point to `docs/story-format.md`)
+  - D2 comment annotations example
+  - JS lib usage example (for embedding in a framework)
+  - Node ID matching rules
+  - Requirements (`d2` must be on PATH for CLI)
+
+- [ ] **Step 2: Run full test suite**
+
+```bash
+cd logic-to-visual/package && npm test
+```
+
+Expected: all tests pass.
+
+- [ ] **Step 3: Final build**
+
+```bash
+npm run build
+```
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add logic-to-visual/package/README.md
+git commit -m "docs(d2-story-viewer): README and story-format reference"
+```

--- a/src/fateforger/agents/tasks/README.md
+++ b/src/fateforger/agents/tasks/README.md
@@ -26,7 +26,7 @@ Notes:
 - Pending-task snapshots fail closed (empty result) when TickTick MCP is unreachable, so timeboxing can continue without noisy hard failures.
 - Uses Notion MCP for sprint-domain operations via the task tools above.
 - Due-task defaults backend is explicitly controlled by `TASKS_DEFAULTS_MEMORY_BACKEND`:
-  `constraint_mcp` (default), `mem0`, `disabled`, or `inherit_timeboxing`.
+  `graphiti` only.
 - If the configured durable backend cannot initialize, TaskMarshal falls back to
   local disk cache (`TASKS_DEFAULTS_CACHE_PATH`) and logs a structured one-time
   warning per user/reason (`mode=fallback_cache`, `reason_code=...`).

--- a/src/fateforger/agents/tasks/defaults_memory.py
+++ b/src/fateforger/agents/tasks/defaults_memory.py
@@ -20,7 +20,6 @@ from fateforger.agents.timeboxing.durable_constraint_store import (
 from fateforger.agents.timeboxing.graphiti_constraint_memory import (
     build_graphiti_client_from_settings,
 )
-from fateforger.agents.timeboxing.mcp_clients import ConstraintMemoryClient
 from fateforger.core.config import settings
 
 logger = logging.getLogger(__name__)
@@ -29,11 +28,7 @@ _DEFAULTS_TOPIC = "taskmarshal-defaults"
 _DEFAULTS_NAME_PREFIX = "taskmarshal-defaults:"
 _DEFAULTS_DESC_PREFIX = "task_defaults_json:"
 _TASK_DEFAULTS_BACKENDS = {
-    "constraint_mcp",
-    "mem0",
     "graphiti",
-    "disabled",
-    "inherit_timeboxing",
 }
 
 
@@ -77,21 +72,12 @@ class TaskDefaultsMemoryStore:
             return self._store
         if self._unavailable_reason:
             return None
-        if self._backend == "disabled":
-            self._unavailable_reason = "tasks defaults durable backend disabled by configuration"
-            self._unavailable_reason_code = "backend_disabled"
-            return None
         try:
-            if self._backend == "constraint_mcp":
-                self._client = ConstraintMemoryClient(timeout=self.timeout_s)
-            elif self._backend == "graphiti":
-                user_id = (
-                    str(getattr(settings, "graphiti_user_id", "") or "").strip()
-                    or "timeboxing"
-                )
-                self._client = build_graphiti_client_from_settings(user_id=user_id)
-            else:
-                raise ValueError(f"Unsupported tasks defaults memory backend: {self._backend}")
+            user_id = (
+                str(getattr(settings, "graphiti_user_id", "") or "").strip()
+                or "timeboxing"
+            )
+            self._client = build_graphiti_client_from_settings(user_id=user_id)
             self._store = build_durable_constraint_store(self._client)
             self._unavailable_reason = None
             self._unavailable_reason_code = None
@@ -227,29 +213,21 @@ class TaskDefaultsMemoryStore:
     @staticmethod
     def _resolve_backend() -> str:
         configured = str(
-            getattr(settings, "tasks_defaults_memory_backend", "constraint_mcp") or ""
+            getattr(settings, "tasks_defaults_memory_backend", "graphiti") or ""
         ).strip().lower()
         if not configured:
-            configured = "constraint_mcp"
-        if configured == "inherit_timeboxing":
-            configured = str(
-                getattr(settings, "timeboxing_memory_backend", "constraint_mcp") or ""
-            ).strip().lower() or "constraint_mcp"
+            configured = "graphiti"
         if configured not in _TASK_DEFAULTS_BACKENDS:
-            return "disabled"
-        if configured == "inherit_timeboxing":
-            return "constraint_mcp"
+            return "graphiti"
         return configured
 
     @staticmethod
     def _classify_unavailable_reason(exc: Exception) -> str:
         message = str(exc).lower()
+        if "openrouter_api_key" in message:
+            return "missing_openrouter_api_key"
         if "openai_api_key" in message:
-            return "missing_openai_api_key"
-        if "mem0_api_key" in message:
-            return "missing_mem0_api_key"
-        if "mem0 backend requires" in message:
-            return "missing_mem0_runtime_config"
+            return "missing_openrouter_api_key"
         if "notion_timeboxing_parent_page_id" in message:
             return "missing_notion_parent_page_id"
         if "notion_token" in message:

--- a/src/fateforger/agents/tasks/defaults_memory.py
+++ b/src/fateforger/agents/tasks/defaults_memory.py
@@ -60,7 +60,9 @@ class TaskDefaultsMemoryStore:
         self._unavailable_reason: str | None = None
         self._unavailable_reason_code: str | None = None
         self._fallback_path = Path(
-            os.getenv("TASKS_DEFAULTS_CACHE_PATH", "logs/taskmarshal_defaults_cache.json")
+            os.getenv(
+                "TASKS_DEFAULTS_CACHE_PATH", "logs/taskmarshal_defaults_cache.json"
+            )
         )
         self._cache_lock = threading.Lock()
         self._cache_mtime_ns: int | None = None
@@ -159,7 +161,8 @@ class TaskDefaultsMemoryStore:
         record = {
             "constraint_record": {
                 "name": f"{_DEFAULTS_NAME_PREFIX}{defaults.user_id}",
-                "description": _DEFAULTS_DESC_PREFIX + json.dumps(payload, sort_keys=True),
+                "description": _DEFAULTS_DESC_PREFIX
+                + json.dumps(payload, sort_keys=True),
                 "necessity": "should",
                 "status": "locked",
                 "source": "user",
@@ -212,9 +215,11 @@ class TaskDefaultsMemoryStore:
 
     @staticmethod
     def _resolve_backend() -> str:
-        configured = str(
-            getattr(settings, "tasks_defaults_memory_backend", "graphiti") or ""
-        ).strip().lower()
+        configured = (
+            str(getattr(settings, "tasks_defaults_memory_backend", "graphiti") or "")
+            .strip()
+            .lower()
+        )
         if not configured:
             configured = "graphiti"
         if configured not in _TASK_DEFAULTS_BACKENDS:
@@ -354,10 +359,14 @@ class TaskDefaultsMemoryStore:
                 except Exception:
                     disk_payload = {}
             disk_payload[defaults.user_id] = defaults.model_dump(mode="json")
-            tmp_path = self._fallback_path.with_suffix(self._fallback_path.suffix + ".tmp")
+            tmp_path = self._fallback_path.with_suffix(
+                self._fallback_path.suffix + ".tmp"
+            )
             try:
                 tmp_path.write_text(
-                    json.dumps(disk_payload, ensure_ascii=True, sort_keys=True, indent=2),
+                    json.dumps(
+                        disk_payload, ensure_ascii=True, sort_keys=True, indent=2
+                    ),
                     encoding="utf-8",
                 )
                 tmp_path.replace(self._fallback_path)

--- a/src/fateforger/agents/timeboxing/README.md
+++ b/src/fateforger/agents/timeboxing/README.md
@@ -16,6 +16,7 @@ Stage-gated timeboxing workflow that builds daily schedules via conversational r
 | Durable profile/date-span constraint auto-upsert + Stage 1 prefetch wait | Implemented, Tested | `test_timeboxing_durable_constraints.py`, `test_timeboxing_constraint_memory_client_tool_name.py` | — |
 | Constraint-memory MCP payload decoding hardening | Implemented, Tested | `test_timeboxing_constraint_memory_client_tool_name.py` | — |
 | Stage 1 lookup-first defaults + session override suppression | Implemented, Tested | `test_timeboxing_durable_constraints.py`, `test_timeboxing_stage_gate_json_context.py` | — |
+| Stage-context conditional default suppression | Implemented, Tested | `test_timeboxing_constraint_selection.py` | — |
 | Stage 3 markdown-first skeleton overview | Implemented, Tested | `test_timeboxing_skeleton_draft_contract.py` | — |
 | Stage 4 advisory quality facts (0-4) | Implemented, Tested | `test_phase4_rewiring.py` | — |
 | Deterministic stage action buttons | Implemented, Tested | `test_timeboxing_stage_actions.py`, `test_slack_timebox_stage_buttons.py` | — |
@@ -27,7 +28,7 @@ Stage-gated timeboxing workflow that builds daily schedules via conversational r
 
 | File | Responsibility |
 |------|---------------|
-| `agent.py` | `PlanningCoordinator`: owns Session, routes Slack messages, runs background tasks, manages stage transitions. Entry points: `on_start()`, `on_commit_date()`, `on_user_reply()`. |
+| `agent.py` | `PlanningCoordinator`: owns Session, routes Slack messages, runs background tasks, manages stage transitions, and performs stage-context constraint selection/suppression. Entry points: `on_start()`, `on_commit_date()`, `on_user_reply()`. |
 | `flow_graph.py` | `build_timeboxing_graphflow()`: constructs the AutoGen GraphFlow DAG. Single source of truth for stage transitions and edge conditions. |
 | `stage_gating.py` | `TimeboxingStage` enum, `StageGateOutput` model, LLM prompt templates for each stage gate. |
 | `contracts.py` | Typed stage-context contracts (`SkeletonContext`, `ConstraintContext`, etc.): what each stage receives as input. |

--- a/src/fateforger/agents/timeboxing/agent.py
+++ b/src/fateforger/agents/timeboxing/agent.py
@@ -50,12 +50,6 @@ from fateforger.llm import (
     build_autogen_chat_client,
 )
 from fateforger.llm.toon import toon_encode
-from fateforger.sync_core import (
-    ReconciliationSummary,
-    SubmitBaselineGuard,
-    evaluate_submit_baseline_guard,
-    summarize_reconciliation,
-)
 from fateforger.slack_bot.constraint_review import (
     CONSTRAINT_REVIEW_ALL_ACTION_ID,
     CONSTRAINT_ROW_REVIEW_ACTION_ID,
@@ -71,6 +65,12 @@ from fateforger.slack_bot.timeboxing_submit import (
     build_review_submit_actions_block,
     build_text_section_block,
     build_undo_submit_actions_block,
+)
+from fateforger.sync_core import (
+    ReconciliationSummary,
+    SubmitBaselineGuard,
+    evaluate_submit_baseline_guard,
+    summarize_reconciliation,
 )
 from fateforger.tools.ticktick_mcp import TickTickMcpClient, get_ticktick_mcp_url
 
@@ -95,8 +95,8 @@ from .durable_constraint_store import (
     build_durable_constraint_store,
 )
 from .flow_graph import build_timeboxing_graphflow
-from .mcp_clients import McpCalendarClient
 from .graphiti_constraint_memory import build_graphiti_client_from_settings
+from .mcp_clients import McpCalendarClient
 from .messages import (
     StartTimeboxing,
     TimeboxingCancelSubmit,
@@ -147,8 +147,8 @@ from .stage_gating import (
     TIMEBOX_SUMMARY_PROMPT,
     ConstraintsSection,
     FreeformSection,
-    NextStepsSection,
     MessageSection,
+    NextStepsSection,
     SessionMessage,
     StageDecision,
     StageGateOutput,
@@ -725,8 +725,10 @@ class TimeboxingFlowAgent(RoutedAgent):
         """Run one GraphFlow turn and return the presenter text message."""
         async with session.graph_turn_lock:
             turn_started_at = perf_counter()
+
             def turn_elapsed_s() -> float:
                 return round(perf_counter() - turn_started_at, 3)
+
             session.graph_turn_started_at_monotonic = turn_started_at
             session.graph_turn_deadline_monotonic = (
                 turn_started_at + TIMEBOXING_TIMEOUTS.graph_turn_s
@@ -1149,7 +1151,9 @@ class TimeboxingFlowAgent(RoutedAgent):
         return parse_chat_content(ConstraintInterpretation, response)
 
     @staticmethod
-    def _serialize_constraint_for_interpretation(constraint: Constraint) -> dict[str, Any]:
+    def _serialize_constraint_for_interpretation(
+        constraint: Constraint,
+    ) -> dict[str, Any]:
         """Serialize one local constraint row for extraction-context prompts."""
         payload = constraint.model_dump(
             mode="json",
@@ -1500,11 +1504,8 @@ class TimeboxingFlowAgent(RoutedAgent):
                                 except Exception:
                                     pass
                     if self._constraint_store:
-                        if (
-                            scope == ConstraintScope.SESSION
-                            and hasattr(
-                                self._constraint_store, "replace_session_constraints"
-                            )
+                        if scope == ConstraintScope.SESSION and hasattr(
+                            self._constraint_store, "replace_session_constraints"
                         ):
                             await self._constraint_store.replace_session_constraints(
                                 user_id=session.user_id,
@@ -2194,10 +2195,7 @@ class TimeboxingFlowAgent(RoutedAgent):
         if not session.pending_constraint_extractions:
             return
         task_map = getattr(self, "_constraint_extraction_tasks", {})
-        tasks = [
-            task_map.get(key)
-            for key in session.pending_constraint_extractions
-        ]
+        tasks = [task_map.get(key) for key in session.pending_constraint_extractions]
         tasks = [task for task in tasks if task]
         if not tasks:
             return
@@ -2696,7 +2694,9 @@ class TimeboxingFlowAgent(RoutedAgent):
                 value.value if isinstance(value, ConstraintDayOfWeek) else str(value)
                 for value in days
             }
-            valid_day = ("MO", "TU", "WE", "TH", "FR", "SA", "SU")[planned_day.weekday()]
+            valid_day = ("MO", "TU", "WE", "TH", "FR", "SA", "SU")[
+                planned_day.weekday()
+            ]
             if valid_day not in day_codes:
                 return False
         return True
@@ -2728,7 +2728,10 @@ class TimeboxingFlowAgent(RoutedAgent):
         planned_day = self._parse_session_planned_day(session)
         fallback: list[Constraint] = []
         for constraint in session.active_constraints or []:
-            if constraint.scope not in (ConstraintScope.PROFILE, ConstraintScope.DATESPAN):
+            if constraint.scope not in (
+                ConstraintScope.PROFILE,
+                ConstraintScope.DATESPAN,
+            ):
                 continue
             if constraint.status == ConstraintStatus.DECLINED:
                 continue
@@ -3103,8 +3106,7 @@ class TimeboxingFlowAgent(RoutedAgent):
         anchors = parse_model_list(Immovable, facts.get("immovables"))
         if anchors:
             anchor_preview = ", ".join(
-                f"{anchor.start}-{anchor.end} {anchor.title}"
-                for anchor in anchors[:3]
+                f"{anchor.start}-{anchor.end} {anchor.title}" for anchor in anchors[:3]
             )
             if len(anchors) > 3:
                 anchor_preview = f"{anchor_preview}, +{len(anchors) - 3} more"
@@ -3241,11 +3243,11 @@ class TimeboxingFlowAgent(RoutedAgent):
             "collect_context_calendar_anchors",
             planned_date=planned_date,
             immovable_count=len(normalized),
-            prefetched_count=len(
-                session.prefetched_immovables_by_date.get(planned_date) or []
-            )
-            if planned_date
-            else 0,
+            prefetched_count=(
+                len(session.prefetched_immovables_by_date.get(planned_date) or [])
+                if planned_date
+                else 0
+            ),
             pending_prefetch=session.pending_calendar_prefetch,
         )
         durable = self._collect_stage_durable_constraints(
@@ -3280,7 +3282,9 @@ class TimeboxingFlowAgent(RoutedAgent):
             prefetched=prefetched,
         )
         task_candidates = parse_model_list(TaskCandidate, input_facts.get("tasks"))
-        filtered_out = max(0, len(session.prefetched_pending_tasks or []) - len(prefetched))
+        filtered_out = max(
+            0, len(session.prefetched_pending_tasks or []) - len(prefetched)
+        )
         self._session_debug(
             session,
             "capture_inputs_task_context",
@@ -3323,7 +3327,9 @@ class TimeboxingFlowAgent(RoutedAgent):
 
         reasons: list[str] = []
         suppress_signals = {"gtd_admin_exclusion", "daily_one_thing"}
-        matched = sorted(signal for signal in scope_signals if signal in suppress_signals)
+        matched = sorted(
+            signal for signal in scope_signals if signal in suppress_signals
+        )
         if matched:
             reasons.append("scope_first_suppress_prefetch")
             reasons.extend(matched)
@@ -3995,7 +4001,8 @@ class TimeboxingFlowAgent(RoutedAgent):
         )
         can_go_back = session.stage != TimeboxingStage.COLLECT_CONSTRAINTS
         can_proceed = (
-            session.stage != TimeboxingStage.REVIEW_COMMIT and session.stage_ready
+            session.stage != TimeboxingStage.REVIEW_COMMIT
+            and session.stage_ready
             and not has_refine_undo
         )
         meta_value = self._build_stage_action_value(session)
@@ -4493,7 +4500,9 @@ class TimeboxingFlowAgent(RoutedAgent):
             raise ValueError("Refine patch requested without TBPlan state.")
         previous_plan = session.tb_plan.model_copy(deep=True)
         previous_timebox = (
-            session.timebox.model_copy(deep=True) if session.timebox is not None else None
+            session.timebox.model_copy(deep=True)
+            if session.timebox is not None
+            else None
         )
         constraints = await self._collect_constraints(session)
         patch_constraints = self._select_constraints_for_refine_patcher(
@@ -4536,9 +4545,7 @@ class TimeboxingFlowAgent(RoutedAgent):
             note=note,
         )
 
-    async def _undo_last_refine_update(
-        self, *, session: Session
-    ) -> TextMessage | None:
+    async def _undo_last_refine_update(self, *, session: Session) -> TextMessage | None:
         """Restore the previous local draft after a Stage 4 patch."""
         if (
             session.stage != TimeboxingStage.REFINE
@@ -5815,8 +5822,10 @@ class TimeboxingFlowAgent(RoutedAgent):
                     ]
                     folded = [line for line in folded if line]
                     if folded:
-                        folded = TimeboxingFlowAgent._compact_constraint_lines_for_slack(
-                            folded
+                        folded = (
+                            TimeboxingFlowAgent._compact_constraint_lines_for_slack(
+                                folded
+                            )
                         )
                         parts.extend(
                             [
@@ -5916,9 +5925,10 @@ class TimeboxingFlowAgent(RoutedAgent):
 
         current_idx: int | None = None
         for idx, section in enumerate(sections):
-            if isinstance(section, FreeformSection) and (
-                section.heading or ""
-            ).strip().lower() == "current step":
+            if (
+                isinstance(section, FreeformSection)
+                and (section.heading or "").strip().lower() == "current step"
+            ):
                 current_idx = idx
                 break
         if current_idx is None:
@@ -5956,8 +5966,8 @@ class TimeboxingFlowAgent(RoutedAgent):
 
         if next_idx is None:
             fallback_question = (
-                (gate.question or "").strip() or "Share what to adjust next."
-            )
+                gate.question or ""
+            ).strip() or "Share what to adjust next."
             sections.append(
                 NextStepsSection(
                     heading="What I need from you",
@@ -6570,9 +6580,7 @@ class TimeboxingFlowAgent(RoutedAgent):
         )
         session.active_constraints = selected_active_constraints
         session.active_constraints_raw_count = len(raw_active_constraints)
-        session.active_constraints_applicable_count = len(
-            applicable_active_constraints
-        )
+        session.active_constraints_applicable_count = len(applicable_active_constraints)
         session.active_constraints_selected_count = len(selected_active_constraints)
         self._session_debug(
             session,
@@ -6589,12 +6597,16 @@ class TimeboxingFlowAgent(RoutedAgent):
             local_shared_canonical_rows=int(
                 shared_stats.get("canonical_shared_rows") or 0
             ),
-            local_shared_duplicate_groups=int(shared_stats.get("duplicate_groups") or 0),
+            local_shared_duplicate_groups=int(
+                shared_stats.get("duplicate_groups") or 0
+            ),
             durable_count=len(durable_constraints),
             active_raw_count=len(raw_active_constraints),
             active_applicable_count=len(applicable_active_constraints),
             active_selected_count=len(selected_active_constraints),
-            active_suppressed_count=int(session.active_constraints_suppressed_count or 0),
+            active_suppressed_count=int(
+                session.active_constraints_suppressed_count or 0
+            ),
             active_suppressed_reasons=list(
                 session.active_constraints_suppressed_reasons or []
             ),
@@ -6745,7 +6757,10 @@ class TimeboxingFlowAgent(RoutedAgent):
             if aspect_id:
                 strongest = strongest_by_aspect.get(aspect_id)
                 if strongest is not None and strongest is not constraint:
-                    if constraint.scope != ConstraintScope.SESSION or aspect_id in session_aspect_ids:
+                    if (
+                        constraint.scope != ConstraintScope.SESSION
+                        or aspect_id in session_aspect_ids
+                    ):
                         suppressed_reasons.append("stronger_same_aspect")
                         continue
 
@@ -6761,13 +6776,18 @@ class TimeboxingFlowAgent(RoutedAgent):
 
             blocked = False
             if aspect_id:
-                candidate_rank = cls._constraint_rank_for_stage_reconciliation(constraint)
+                candidate_rank = cls._constraint_rank_for_stage_reconciliation(
+                    constraint
+                )
                 for other in constraints or []:
                     if other is constraint:
                         continue
                     if aspect_id not in cls._constraint_excludes_aspect_ids(other):
                         continue
-                    if cls._constraint_rank_for_stage_reconciliation(other) <= candidate_rank:
+                    if (
+                        cls._constraint_rank_for_stage_reconciliation(other)
+                        <= candidate_rank
+                    ):
                         blocked = True
                         break
             if blocked:
@@ -6910,7 +6930,9 @@ class TimeboxingFlowAgent(RoutedAgent):
             }
             classification = ConstraintAspectClassification.from_hints(hints)
             has_temporal_window = bool(
-                constraint.start_date or constraint.end_date or (constraint.days_of_week or [])
+                constraint.start_date
+                or constraint.end_date
+                or (constraint.days_of_week or [])
             )
             is_structured = bool(classification is not None)
             is_startup_prefetch = bool(
@@ -6918,10 +6940,17 @@ class TimeboxingFlowAgent(RoutedAgent):
                 or (classification.is_startup_prefetch if classification else False)
             )
             is_frame_anchor = bool(
-                classification and classification.frame_slot in {"sleep_target", "work_window"}
+                classification
+                and classification.frame_slot in {"sleep_target", "work_window"}
             )
             is_locked = constraint.status == ConstraintStatus.LOCKED
-            if is_startup_prefetch or is_frame_anchor or is_locked or is_structured or has_temporal_window:
+            if (
+                is_startup_prefetch
+                or is_frame_anchor
+                or is_locked
+                or is_structured
+                or has_temporal_window
+            ):
                 out.append(constraint)
         return out
 
@@ -6966,7 +6995,9 @@ class TimeboxingFlowAgent(RoutedAgent):
             if constraint.necessity == ConstraintNecessity.MUST
         ]
         selected: list[Constraint] = list(session_constraints)
-        seen: set[str] = {_constraint_identity_key(constraint) for constraint in selected}
+        seen: set[str] = {
+            _constraint_identity_key(constraint) for constraint in selected
+        }
         durable_selected = 0
         for constraint in [*must_constraints, *durable_constraints]:
             key = _constraint_identity_key(constraint)
@@ -7773,7 +7804,9 @@ class TimeboxingFlowAgent(RoutedAgent):
     @staticmethod
     def _submit_attempt_kind(session: Session) -> Literal["first_submit", "resubmit"]:
         """Return submit attempt kind for telemetry and UX clarity."""
-        return "resubmit" if session.last_sync_transaction is not None else "first_submit"
+        return (
+            "resubmit" if session.last_sync_transaction is not None else "first_submit"
+        )
 
     def _build_submit_incomplete_reply(self) -> TextMessage:
         """Return deterministic copy when submit is requested before prerequisites exist."""
@@ -8549,11 +8582,7 @@ def _constraint_canonical_rank(constraint: Constraint) -> tuple[int, int, float,
     if necessity_value not in necessity_rank and necessity_value is not None:
         necessity_value = str(necessity_value).lower()
     updated = getattr(constraint, "updated_at", None)
-    updated_epoch = (
-        updated.timestamp()
-        if isinstance(updated, datetime)
-        else 0.0
-    )
+    updated_epoch = updated.timestamp() if isinstance(updated, datetime) else 0.0
     return (
         status_rank.get(constraint.status, 3),
         necessity_rank.get(necessity_value, 3),
@@ -8581,6 +8610,7 @@ def _constraint_applies_to_stage(
     stage: TimeboxingStage,
 ) -> bool:
     """Return whether a constraint is applicable for the current stage."""
+
     def _as_list(value: object) -> list[object]:
         if isinstance(value, list):
             return value
@@ -8595,7 +8625,9 @@ def _constraint_applies_to_stage(
     )
     if not raw_stages:
         return True
-    normalized = {str(value).strip().lower() for value in raw_stages if str(value).strip()}
+    normalized = {
+        str(value).strip().lower() for value in raw_stages if str(value).strip()
+    }
     return stage.value.strip().lower() in normalized
 
 
@@ -8675,10 +8707,7 @@ def _constraint_count_summary_line(
         refine_selected_total = max(
             0, int(session.last_refine_selected_constraints_count or 0)
         )
-        parts.append(
-            "Selected for Refine patching: "
-            f"{refine_selected_total}."
-        )
+        parts.append("Selected for Refine patching: " f"{refine_selected_total}.")
         kept_total = refine_selected_total
     elif 0 < selected_total < applicable_total:
         parts.append(f"Selected for this stage: {selected_total}.")

--- a/src/fateforger/agents/timeboxing/agent.py
+++ b/src/fateforger/agents/timeboxing/agent.py
@@ -95,7 +95,7 @@ from .durable_constraint_store import (
     build_durable_constraint_store,
 )
 from .flow_graph import build_timeboxing_graphflow
-from .mcp_clients import ConstraintMemoryClient, McpCalendarClient
+from .mcp_clients import McpCalendarClient
 from .graphiti_constraint_memory import build_graphiti_client_from_settings
 from .messages import (
     StartTimeboxing,
@@ -148,6 +148,7 @@ from .stage_gating import (
     ConstraintsSection,
     FreeformSection,
     NextStepsSection,
+    MessageSection,
     SessionMessage,
     StageDecision,
     StageGateOutput,
@@ -202,6 +203,7 @@ class _ConstraintInterpretationPayload(BaseModel):
     planned_date: str | None = None
     timezone: str | None = None
     stage_id: str | None = None
+    existing_constraints: list[dict[str, Any]] = PydanticField(default_factory=list)
 
 
 class _ConstraintOverviewView(BaseModel):
@@ -295,6 +297,8 @@ class Session:
     active_constraints_raw_count: int = 0
     active_constraints_applicable_count: int = 0
     active_constraints_selected_count: int = 0
+    active_constraints_suppressed_count: int = 0
+    active_constraints_suppressed_reasons: list[str] = field(default_factory=list)
     last_extracted_constraints_count: int = 0
     last_refine_selected_constraints_count: int = 0
     durable_constraints_by_stage: Dict[str, List[Constraint]] = field(
@@ -721,7 +725,8 @@ class TimeboxingFlowAgent(RoutedAgent):
         """Run one GraphFlow turn and return the presenter text message."""
         async with session.graph_turn_lock:
             turn_started_at = perf_counter()
-            turn_elapsed_s = lambda: round(perf_counter() - turn_started_at, 3)
+            def turn_elapsed_s() -> float:
+                return round(perf_counter() - turn_started_at, 3)
             session.graph_turn_started_at_monotonic = turn_started_at
             session.graph_turn_deadline_monotonic = (
                 turn_started_at + TIMEBOXING_TIMEOUTS.graph_turn_s
@@ -964,30 +969,21 @@ class TimeboxingFlowAgent(RoutedAgent):
             return self._constraint_memory_client
         if self._constraint_memory_unavailable_reason:
             return None
-        backend = str(getattr(settings, "timeboxing_memory_backend", "constraint_mcp"))
+        backend = str(getattr(settings, "timeboxing_memory_backend", "graphiti"))
         backend = backend.strip().lower()
         try:
-            timeout = float(
-                getattr(settings, "agent_mcp_discovery_timeout_seconds", 10)
+            if backend != "graphiti":
+                raise ValueError(
+                    "Unsupported timeboxing memory backend: "
+                    f"{settings.timeboxing_memory_backend}"
+                )
+            user_id = (
+                str(getattr(settings, "graphiti_user_id", "") or "").strip()
+                or "timeboxing"
             )
-            match backend:
-                case "constraint_mcp":
-                    self._constraint_memory_client = ConstraintMemoryClient(
-                        timeout=timeout
-                    )
-                case "graphiti":
-                    user_id = (
-                        str(getattr(settings, "graphiti_user_id", "") or "").strip()
-                        or "timeboxing"
-                    )
-                    self._constraint_memory_client = build_graphiti_client_from_settings(
-                        user_id=user_id
-                    )
-                case _:
-                    raise ValueError(
-                        "Unsupported timeboxing memory backend: "
-                        f"{settings.timeboxing_memory_backend}"
-                    )
+            self._constraint_memory_client = build_graphiti_client_from_settings(
+                user_id=user_id
+            )
             self._constraint_memory_unavailable_reason = None
         except Exception as exc:
             self._constraint_memory_unavailable_reason = f"{type(exc).__name__}: {exc}"
@@ -1138,6 +1134,9 @@ class TimeboxingFlowAgent(RoutedAgent):
             planned_date=session.planned_date,
             timezone=session.tz_name,
             stage_id=session.stage.value if session.stage else None,
+            existing_constraints=await self._list_session_constraints_for_interpretation(
+                session
+            ),
         )
         response = await with_timeout(
             "timeboxing:constraint-interpret",
@@ -1148,6 +1147,54 @@ class TimeboxingFlowAgent(RoutedAgent):
             timeout_s=TIMEBOXING_TIMEOUTS.constraint_interpret_s,
         )
         return parse_chat_content(ConstraintInterpretation, response)
+
+    @staticmethod
+    def _serialize_constraint_for_interpretation(constraint: Constraint) -> dict[str, Any]:
+        """Serialize one local constraint row for extraction-context prompts."""
+        payload = constraint.model_dump(
+            mode="json",
+            exclude={
+                "id",
+                "user_id",
+                "channel_id",
+                "thread_ts",
+                "created_at",
+                "updated_at",
+            },
+        )
+        hints = payload.get("hints")
+        if isinstance(hints, dict):
+            uid = str(hints.get("uid") or "").strip()
+            if uid:
+                payload["uid"] = uid
+        return payload
+
+    async def _list_session_constraints_for_interpretation(
+        self, session: Session
+    ) -> list[dict[str, Any]]:
+        """Return current in-thread session constraints for extraction reconciliation."""
+        ensure_store = getattr(self, "_ensure_constraint_store", None)
+        if callable(ensure_store) and hasattr(self, "_constraint_store"):
+            await ensure_store()
+        store = getattr(self, "_constraint_store", None)
+        if store:
+            rows = await store.list_constraints(
+                user_id=session.user_id,
+                channel_id=session.channel_id,
+                thread_ts=session.thread_ts,
+                scope=ConstraintScope.SESSION,
+            )
+            return [
+                self._serialize_constraint_for_interpretation(row)
+                for row in rows
+                if row.status != ConstraintStatus.DECLINED
+            ]
+        return [
+            self._serialize_constraint_for_interpretation(row)
+            for row in (session.active_constraints or [])
+            if row.scope == ConstraintScope.SESSION
+            and row.status != ConstraintStatus.DECLINED
+        ]
 
     # TODO: this should be part of a tool, not bolted onto an agent
     def _constraint_task_key(self, session: Session, text: str) -> str:
@@ -1453,7 +1500,19 @@ class TimeboxingFlowAgent(RoutedAgent):
                                 except Exception:
                                     pass
                     if self._constraint_store:
-                        if hasattr(self._constraint_store, "upsert_constraints"):
+                        if (
+                            scope == ConstraintScope.SESSION
+                            and hasattr(
+                                self._constraint_store, "replace_session_constraints"
+                            )
+                        ):
+                            await self._constraint_store.replace_session_constraints(
+                                user_id=session.user_id,
+                                channel_id=session.channel_id,
+                                thread_ts=session.thread_ts,
+                                constraints=constraints,
+                            )
+                        elif hasattr(self._constraint_store, "upsert_constraints"):
                             await self._constraint_store.upsert_constraints(
                                 user_id=session.user_id,
                                 channel_id=session.channel_id,
@@ -6535,6 +6594,10 @@ class TimeboxingFlowAgent(RoutedAgent):
             active_raw_count=len(raw_active_constraints),
             active_applicable_count=len(applicable_active_constraints),
             active_selected_count=len(selected_active_constraints),
+            active_suppressed_count=int(session.active_constraints_suppressed_count or 0),
+            active_suppressed_reasons=list(
+                session.active_constraints_suppressed_reasons or []
+            ),
             active_filtered_out_count=max(
                 0, len(raw_active_constraints) - len(applicable_active_constraints)
             ),
@@ -6556,8 +6619,17 @@ class TimeboxingFlowAgent(RoutedAgent):
         """Reconcile duplicate families and keep stage-relevant constraints only."""
         stage = session.stage
         session_aspect_ids = self._collect_session_aspect_ids(constraints)
+        (
+            eligible_constraints,
+            suppressed_reasons,
+        ) = self._filter_constraints_for_conditional_applicability(
+            constraints=constraints,
+            session_aspect_ids=session_aspect_ids,
+        )
+        session.active_constraints_suppressed_count = len(suppressed_reasons)
+        session.active_constraints_suppressed_reasons = list(suppressed_reasons)
         reconciled_groups: dict[str, list[Constraint]] = {}
-        for constraint in constraints or []:
+        for constraint in eligible_constraints:
             family_key = self._constraint_relevance_family_key(constraint)
             reconciled_groups.setdefault(family_key, []).append(constraint)
 
@@ -6596,6 +6668,114 @@ class TimeboxingFlowAgent(RoutedAgent):
             if aspect_id:
                 aspect_ids.add(aspect_id)
         return aspect_ids
+
+    @classmethod
+    def _collect_active_aspect_ids(cls, constraints: list[Constraint]) -> set[str]:
+        """Collect all aspect IDs currently present in the candidate set."""
+        aspect_ids: set[str] = set()
+        for constraint in constraints or []:
+            aspect_id = cls._constraint_aspect_id(constraint)
+            if aspect_id:
+                aspect_ids.add(aspect_id)
+        return aspect_ids
+
+    @staticmethod
+    def _constraint_excludes_aspect_ids(constraint: Constraint) -> set[str]:
+        """Return structured aspect exclusions for one constraint."""
+        hints = constraint.hints if isinstance(constraint.hints, dict) else {}
+        classification = ConstraintAspectClassification.from_hints(hints)
+        if classification is None:
+            return set()
+        return {
+            str(item).strip().lower()
+            for item in (classification.excludes_aspect_ids or [])
+            if str(item).strip()
+        }
+
+    @staticmethod
+    def _constraint_conditional_absent_ids(constraint: Constraint) -> set[str]:
+        """Return structured aspect IDs that must be absent for applicability."""
+        hints = constraint.hints if isinstance(constraint.hints, dict) else {}
+        classification = ConstraintAspectClassification.from_hints(hints)
+        if classification is None:
+            return set()
+        return {
+            str(item).strip().lower()
+            for item in (classification.conditional_on_absent or [])
+            if str(item).strip()
+        }
+
+    @staticmethod
+    def _constraint_conditional_present_ids(constraint: Constraint) -> set[str]:
+        """Return structured aspect IDs that must be present for applicability."""
+        hints = constraint.hints if isinstance(constraint.hints, dict) else {}
+        classification = ConstraintAspectClassification.from_hints(hints)
+        if classification is None:
+            return set()
+        return {
+            str(item).strip().lower()
+            for item in (classification.conditional_on_present or [])
+            if str(item).strip()
+        }
+
+    @classmethod
+    def _filter_constraints_for_conditional_applicability(
+        cls,
+        *,
+        constraints: list[Constraint],
+        session_aspect_ids: set[str],
+    ) -> tuple[list[Constraint], list[str]]:
+        """Suppress defaults/profile constraints when stronger same-day facts conflict."""
+        active_aspect_ids = cls._collect_active_aspect_ids(constraints)
+        strongest_by_aspect: dict[str, Constraint] = {}
+        for constraint in constraints or []:
+            aspect_id = cls._constraint_aspect_id(constraint)
+            if not aspect_id:
+                continue
+            current = strongest_by_aspect.get(aspect_id)
+            if current is None or cls._constraint_rank_for_stage_reconciliation(
+                constraint
+            ) < cls._constraint_rank_for_stage_reconciliation(current):
+                strongest_by_aspect[aspect_id] = constraint
+
+        eligible: list[Constraint] = []
+        suppressed_reasons: list[str] = []
+        for constraint in constraints or []:
+            aspect_id = cls._constraint_aspect_id(constraint)
+            if aspect_id:
+                strongest = strongest_by_aspect.get(aspect_id)
+                if strongest is not None and strongest is not constraint:
+                    if constraint.scope != ConstraintScope.SESSION or aspect_id in session_aspect_ids:
+                        suppressed_reasons.append("stronger_same_aspect")
+                        continue
+
+            required_present = cls._constraint_conditional_present_ids(constraint)
+            if required_present and not (required_present & active_aspect_ids):
+                suppressed_reasons.append("conditional_on_present")
+                continue
+
+            required_absent = cls._constraint_conditional_absent_ids(constraint)
+            if required_absent & (active_aspect_ids - {aspect_id}):
+                suppressed_reasons.append("conditional_on_absent")
+                continue
+
+            blocked = False
+            if aspect_id:
+                candidate_rank = cls._constraint_rank_for_stage_reconciliation(constraint)
+                for other in constraints or []:
+                    if other is constraint:
+                        continue
+                    if aspect_id not in cls._constraint_excludes_aspect_ids(other):
+                        continue
+                    if cls._constraint_rank_for_stage_reconciliation(other) <= candidate_rank:
+                        blocked = True
+                        break
+            if blocked:
+                suppressed_reasons.append("excluded_by_aspect")
+                continue
+
+            eligible.append(constraint)
+        return eligible, suppressed_reasons
 
     @staticmethod
     def _constraint_rank_for_stage_reconciliation(
@@ -6696,9 +6876,6 @@ class TimeboxingFlowAgent(RoutedAgent):
         self, *, session: Session, relevant_stage_keys: tuple[str, ...]
     ) -> bool:
         """Decide whether shared local constraints should be queried for this turn."""
-        backend = str(getattr(settings, "timeboxing_memory_backend", "") or "").strip().lower()
-        if backend != "graphiti":
-            return True
         if session.pending_durable_constraints:
             return False
         for stage_key in relevant_stage_keys:
@@ -6754,35 +6931,51 @@ class TimeboxingFlowAgent(RoutedAgent):
         session: Session,
         constraints: list[Constraint],
     ) -> list[Constraint]:
-        """Keep Stage 4 patching bounded by selecting the highest-priority constraints."""
+        """Keep all session constraints and cap only durable constraints for Stage 4."""
         ranked = sorted(constraints or [], key=_constraint_priority)
-        limit = max(1, TIMEBOXING_LIMITS.refine_patcher_constraint_limit)
-        if len(ranked) <= limit:
-            session.last_refine_selected_constraints_count = len(ranked)
+        limit = max(0, TIMEBOXING_LIMITS.refine_patcher_constraint_limit)
+        session_constraints = [
+            constraint
+            for constraint in ranked
+            if constraint.scope == ConstraintScope.SESSION
+        ]
+        durable_constraints = [
+            constraint
+            for constraint in ranked
+            if constraint.scope != ConstraintScope.SESSION
+        ]
+        if len(durable_constraints) <= limit:
+            selected = [*session_constraints, *durable_constraints]
+            session.last_refine_selected_constraints_count = len(selected)
             self._session_debug(
                 session,
                 "refine_constraints_selected",
                 total=len(ranked),
-                selected=len(ranked),
-                dropped=0,
-                limit=limit,
+                selected=len(selected),
+                session_selected=len(session_constraints),
+                durable_total=len(durable_constraints),
+                durable_selected=len(durable_constraints),
+                durable_dropped=0,
+                durable_limit=limit,
             )
-            return ranked
+            return selected
 
         must_constraints = [
             constraint
-            for constraint in ranked
+            for constraint in durable_constraints
             if constraint.necessity == ConstraintNecessity.MUST
         ]
-        selected: list[Constraint] = []
-        seen: set[str] = set()
-        for constraint in [*must_constraints, *ranked]:
+        selected: list[Constraint] = list(session_constraints)
+        seen: set[str] = {_constraint_identity_key(constraint) for constraint in selected}
+        durable_selected = 0
+        for constraint in [*must_constraints, *durable_constraints]:
             key = _constraint_identity_key(constraint)
             if key in seen:
                 continue
             seen.add(key)
             selected.append(constraint)
-            if len(selected) >= limit:
+            durable_selected += 1
+            if durable_selected >= limit:
                 break
 
         session.last_refine_selected_constraints_count = len(selected)
@@ -6791,8 +6984,11 @@ class TimeboxingFlowAgent(RoutedAgent):
             "refine_constraints_selected",
             total=len(ranked),
             selected=len(selected),
-            dropped=max(0, len(ranked) - len(selected)),
-            limit=limit,
+            session_selected=len(session_constraints),
+            durable_total=len(durable_constraints),
+            durable_selected=durable_selected,
+            durable_dropped=max(0, len(durable_constraints) - durable_selected),
+            durable_limit=limit,
             selected_names=[
                 (constraint.name or "").strip()
                 for constraint in selected[:10]
@@ -6833,8 +7029,6 @@ class TimeboxingFlowAgent(RoutedAgent):
                 }
             )
             to_add.append(ConstraintBase.model_validate(payload))
-        upsert_added = 0
-        upsert_skipped = 0
         if to_add:
             persisted_rows = await self._constraint_store.add_constraints(
                 user_id=session.user_id,
@@ -8478,12 +8672,24 @@ def _constraint_count_summary_line(
     if raw_total > applicable_total:
         parts.append(f"Raw active rows before filtering: {raw_total}.")
     if session.stage == TimeboxingStage.REFINE:
+        refine_selected_total = max(
+            0, int(session.last_refine_selected_constraints_count or 0)
+        )
         parts.append(
             "Selected for Refine patching: "
-            f"{max(0, int(session.last_refine_selected_constraints_count or 0))}."
+            f"{refine_selected_total}."
         )
+        kept_total = refine_selected_total
     elif 0 < selected_total < applicable_total:
         parts.append(f"Selected for this stage: {selected_total}.")
+        kept_total = selected_total
+    else:
+        kept_total = applicable_total
+    overridden_total = max(0, applicable_total - kept_total)
+    if overridden_total:
+        parts.append(
+            f"Conflict resolution: kept {kept_total}, overridden {overridden_total}."
+        )
     return " ".join(parts)
 
 

--- a/src/fateforger/agents/timeboxing/durable_constraint_store.py
+++ b/src/fateforger/agents/timeboxing/durable_constraint_store.py
@@ -1,6 +1,6 @@
 """Backend-agnostic durable constraint store adapter.
 
-This module wraps the concrete durable-memory clients (Mem0, etc.)
+This module wraps concrete durable-memory clients (Graphiti, MCP, etc.)
 behind one small interface so orchestration code can stay backend-neutral.
 """
 
@@ -587,7 +587,6 @@ class ClientBackedDurableConstraintStore:
         )
         groups: dict[str, list[dict[str, Any]]] = {}
         for entry in await self._load_constraint_entries(rows=rows):
-            uid = _to_text(entry.get("uid"))
             constraint = _constraint_record(entry)
             key, _ = _semantic_identity(constraint)
             groups.setdefault(key, []).append(entry)

--- a/src/fateforger/agents/timeboxing/graphiti_constraint_memory.py
+++ b/src/fateforger/agents/timeboxing/graphiti_constraint_memory.py
@@ -1,111 +1,18 @@
 """Graphiti-backed durable constraint memory adapter.
 
-Current implementation provides a local JSON-backed temporal memory substrate
-with the same contract as the legacy mem0 adapter so orchestration can switch
-backend paths without changing the durable store interface.
+This adapter reuses the durable-memory contract from ``Mem0ConstraintMemoryClient``
+but does not provide a local JSON fallback. Runtime configuration must point to a
+real Graphiti-compatible backend (cloud or local runtime config).
 """
 
 from __future__ import annotations
 
 import json
-from datetime import datetime, timezone
-from pathlib import Path
-from threading import Lock
 from typing import Any
-from uuid import uuid4
-
-from autogen_core.memory import MemoryContent, MemoryQueryResult
 
 from fateforger.core.config import settings
 
 from .mem0_constraint_memory import Mem0ConstraintMemoryClient
-
-
-class _GraphitiLocalMemoryBackend:
-    """Minimal local backend that mimics memory add/query behavior."""
-
-    def __init__(self, *, path: str, user_id: str, limit: int) -> None:
-        self._path = Path(path)
-        self._path.parent.mkdir(parents=True, exist_ok=True)
-        self._user_id = str(user_id or "").strip() or "timeboxing"
-        self._limit = max(1, int(limit))
-        self._lock = Lock()
-        self._rows: list[dict[str, Any]] = []
-        self._load()
-
-    @property
-    def path(self) -> str:
-        return str(self._path)
-
-    def _load(self) -> None:
-        if not self._path.exists():
-            self._rows = []
-            return
-        try:
-            payload = json.loads(self._path.read_text(encoding="utf-8"))
-        except Exception:
-            payload = []
-        self._rows = payload if isinstance(payload, list) else []
-
-    def _persist(self) -> None:
-        self._path.write_text(
-            json.dumps(self._rows, ensure_ascii=True, sort_keys=True),
-            encoding="utf-8",
-        )
-
-    async def add(self, content: MemoryContent) -> None:
-        """Persist one memory row."""
-        metadata = dict(content.metadata or {})
-        if not metadata.get("memory_id"):
-            metadata["memory_id"] = f"graphiti:{uuid4().hex}"
-        now_iso = datetime.now(timezone.utc).isoformat()
-        metadata.setdefault("updated_at", now_iso)
-        metadata.setdefault("user_id", self._user_id)
-
-        row = {
-            "content": str(content.content or ""),
-            "mime_type": str(content.mime_type or "text/plain"),
-            "metadata": metadata,
-            "created_at": now_iso,
-        }
-        with self._lock:
-            self._rows.append(row)
-            self._persist()
-
-    async def query(self, query: str, *, limit: int = 50) -> MemoryQueryResult:
-        """Query memories with deterministic lexical ranking."""
-        query_terms = [term for term in str(query or "").lower().split() if term]
-        row_limit = max(1, int(limit or self._limit))
-        with self._lock:
-            rows = list(self._rows)
-        scored: list[tuple[int, str, dict[str, Any]]] = []
-        for row in rows:
-            metadata = dict(row.get("metadata") or {})
-            row_user = str(metadata.get("user_id") or "").strip()
-            if row_user and row_user != self._user_id:
-                continue
-            blob = (
-                str(row.get("content") or "")
-                + " "
-                + json.dumps(metadata, ensure_ascii=True, sort_keys=True)
-            ).lower()
-            score = 0
-            for term in query_terms:
-                if term in blob:
-                    score += 1
-            scored.append((score, str(metadata.get("updated_at") or ""), row))
-        scored.sort(key=lambda item: (-item[0], item[1]), reverse=False)
-        results: list[MemoryContent] = []
-        for _, _, row in scored[:row_limit]:
-            results.append(
-                MemoryContent(
-                    content=str(row.get("content") or ""),
-                    mime_type=str(row.get("mime_type") or "text/plain"),
-                    metadata=dict(row.get("metadata") or {}),
-                )
-            )
-        return MemoryQueryResult(results=results)
-
 
 class GraphitiConstraintMemoryClient(Mem0ConstraintMemoryClient):
     """Graphiti backend using the durable constraint contract."""
@@ -115,32 +22,35 @@ class GraphitiConstraintMemoryClient(Mem0ConstraintMemoryClient):
         *,
         user_id: str,
         limit: int = 200,
+        is_cloud: bool = False,
+        api_key: str | None = None,
         local_config: dict[str, Any] | None = None,
-        memory_backend: Any | None = None,
+        cloud_url: str = "",
     ) -> None:
-        local = dict(local_config or {})
-        path = str(local.get("path") or "./data/graphiti_memory.json")
-        backend = memory_backend or _GraphitiLocalMemoryBackend(
-            path=path,
-            user_id=user_id,
-            limit=limit,
-        )
         super().__init__(
             user_id=user_id,
             limit=limit,
-            is_cloud=False,
-            local_config=None,
-            memory_backend=backend,
+            is_cloud=is_cloud,
+            api_key=api_key,
+            local_config=local_config,
         )
-        self._graphiti_path = path
+        self._graphiti_is_cloud = bool(is_cloud)
+        self._graphiti_cloud_url = str(cloud_url or "").strip()
+        self._graphiti_local_config = dict(local_config or {})
 
     async def get_store_info(self) -> dict[str, Any]:
-        return {
+        info = {
             "backend": "graphiti",
             "user_id": self._user_id,
             "limit": self._limit,
-            "path": self._graphiti_path,
+            "is_cloud": self._graphiti_is_cloud,
         }
+        if self._graphiti_is_cloud:
+            if self._graphiti_cloud_url:
+                info["cloud_url"] = self._graphiti_cloud_url
+        elif self._graphiti_local_config:
+            info["local_config_keys"] = sorted(self._graphiti_local_config.keys())
+        return info
 
     async def upsert_constraint(
         self,
@@ -159,10 +69,16 @@ def build_graphiti_client_from_settings(*, user_id: str) -> GraphitiConstraintMe
         getattr(settings, "graphiti_local_config_json", "") or ""
     ).strip()
     local_config = json.loads(local_config_raw) if local_config_raw else None
+    is_cloud = bool(getattr(settings, "graphiti_is_cloud", False))
+    api_key = (getattr(settings, "graphiti_api_key", "") or "").strip() or None
+    cloud_url = (getattr(settings, "graphiti_cloud_url", "") or "").strip()
     return GraphitiConstraintMemoryClient(
         user_id=user_id,
         limit=int(getattr(settings, "graphiti_query_limit", 200) or 200),
+        is_cloud=is_cloud,
+        api_key=api_key,
         local_config=local_config,
+        cloud_url=cloud_url,
     )
 
 

--- a/src/fateforger/agents/timeboxing/graphiti_constraint_memory.py
+++ b/src/fateforger/agents/timeboxing/graphiti_constraint_memory.py
@@ -1,55 +1,270 @@
 """Graphiti-backed durable constraint memory adapter.
 
-This adapter reuses the durable-memory contract from ``Mem0ConstraintMemoryClient``
-but does not provide a local JSON fallback. Runtime configuration must point to a
-real Graphiti-compatible backend (cloud or local runtime config).
+This adapter uses Graphiti MCP as the persistence/query backend and keeps the
+existing durable-memory contract used by the timeboxing agent.
 """
 
 from __future__ import annotations
 
+import asyncio
 import json
+from datetime import datetime, timezone
 from typing import Any
+from uuid import uuid4
+
+from autogen_core.memory import MemoryContent, MemoryQueryResult
+from autogen_ext.tools.mcp import McpWorkbench, StreamableHttpServerParams
 
 from fateforger.core.config import settings
 
 from .mem0_constraint_memory import Mem0ConstraintMemoryClient
 
+
+class _GraphitiMcpMemoryBackend:
+    """Minimal memory backend adapter over Graphiti MCP tools."""
+
+    _RECOVERABLE_ERROR_MARKERS = (
+        "timed out while waiting for response",
+        "all connection attempts failed",
+        "connection refused",
+        "server disconnected",
+    )
+
+    def __init__(
+        self,
+        *,
+        server_url: str,
+        group_id: str,
+        user_id: str,
+        timeout_s: float,
+        ingest_wait_s: float = 12.0,
+    ) -> None:
+        self._server_url = server_url
+        self._group_id = group_id
+        self._user_id = user_id
+        self._timeout_s = timeout_s
+        self._ingest_wait_s = max(0.0, float(ingest_wait_s))
+        params = StreamableHttpServerParams(url=self._server_url, timeout=self._timeout_s)
+        self._workbench = McpWorkbench(params)
+        self._lock = asyncio.Lock()
+
+    @staticmethod
+    def _decode_tool_json(tool_name: str, result: Any) -> Any:
+        if isinstance(result, (dict, list)):
+            return result
+        to_text = getattr(result, "to_text", None)
+        text = to_text() if callable(to_text) else str(result)
+        text = (text or "").strip()
+        if not text:
+            return {}
+        if text.startswith("```"):
+            lines = text.splitlines()
+            if lines and lines[0].startswith("```"):
+                lines = lines[1:]
+            if lines and lines[-1].strip() == "```":
+                lines = lines[:-1]
+            text = "\n".join(lines).strip()
+        try:
+            return json.loads(text)
+        except Exception as exc:
+            raise RuntimeError(
+                f"graphiti tool {tool_name} returned non-JSON text: {text[:400]}"
+            ) from exc
+
+    @classmethod
+    def _is_recoverable_transport_error(cls, exc: Exception) -> bool:
+        text = str(exc or "").strip().lower()
+        if not text:
+            return False
+        return any(marker in text for marker in cls._RECOVERABLE_ERROR_MARKERS)
+
+    async def _call_tool_json(self, tool_name: str, *, arguments: dict[str, Any]) -> Any:
+        attempts = 2
+        for attempt in range(1, attempts + 1):
+            try:
+                async with self._lock:
+                    result = await self._workbench.call_tool(tool_name, arguments=arguments)
+                return self._decode_tool_json(tool_name, result)
+            except Exception as exc:
+                if attempt >= attempts or not self._is_recoverable_transport_error(exc):
+                    raise
+                await asyncio.sleep(0.25 * attempt)
+        raise RuntimeError(f"graphiti tool {tool_name} failed unexpectedly")
+
+    async def _list_episodes(self, *, max_episodes: int) -> list[dict[str, Any]]:
+        payload = await self._call_tool_json(
+            "get_episodes",
+            arguments={
+                "group_ids": [self._group_id],
+                "max_episodes": max(1, int(max_episodes)),
+            },
+        )
+        episodes = payload.get("episodes") if isinstance(payload, dict) else None
+        if not isinstance(episodes, list):
+            return []
+        return [item for item in episodes if isinstance(item, dict)]
+
+    async def _list_memory_rows(self, *, max_records: int) -> list[dict[str, Any]]:
+        rows: list[dict[str, Any]] = []
+        for episode in await self._list_episodes(max_episodes=max_records):
+            content_raw = str(episode.get("content") or "").strip()
+            if not content_raw:
+                continue
+            try:
+                payload = json.loads(content_raw)
+            except Exception:
+                payload = {
+                    "content": content_raw,
+                    "mime_type": "text/plain",
+                    "metadata": {},
+                }
+            if not isinstance(payload, dict):
+                continue
+            metadata = dict(payload.get("metadata") or {})
+            metadata.setdefault("memory_id", str(episode.get("uuid") or "").strip())
+            metadata.setdefault(
+                "updated_at",
+                str(episode.get("created_at") or datetime.now(timezone.utc).isoformat()),
+            )
+            metadata.setdefault("user_id", self._user_id)
+            rows.append(
+                {
+                    "content": str(payload.get("content") or ""),
+                    "mime_type": str(payload.get("mime_type") or "text/plain"),
+                    "metadata": metadata,
+                    "created_at": str(episode.get("created_at") or ""),
+                    "name": str(episode.get("name") or ""),
+                }
+            )
+        return rows
+
+    async def status(self) -> dict[str, Any]:
+        payload = await self._call_tool_json("get_status", arguments={})
+        return payload if isinstance(payload, dict) else {"status": "unknown"}
+
+    async def add(self, content: MemoryContent) -> None:
+        metadata = dict(content.metadata or {})
+        if not metadata.get("memory_id"):
+            metadata["memory_id"] = f"graphiti:{uuid4().hex}"
+        metadata.setdefault("updated_at", datetime.now(timezone.utc).isoformat())
+        metadata.setdefault("user_id", self._user_id)
+        row = {
+            "content": str(content.content or ""),
+            "mime_type": str(content.mime_type or "text/plain"),
+            "metadata": metadata,
+        }
+        name = (
+            str(metadata.get("uid") or "").strip()
+            or str(metadata.get("name") or "").strip()
+            or str(metadata.get("kind") or "").strip()
+            or "timeboxing-memory"
+        )
+        await self._call_tool_json(
+            "add_memory",
+            arguments={
+                "name": name,
+                "episode_body": json.dumps(row, ensure_ascii=True, sort_keys=True),
+                "group_id": self._group_id,
+                "source": "json",
+                "source_description": "fateforger_graphiti_memory",
+            },
+        )
+        if self._ingest_wait_s <= 0:
+            return
+        wanted_memory_id = str(metadata.get("memory_id") or "").strip()
+        deadline = asyncio.get_event_loop().time() + self._ingest_wait_s
+        while asyncio.get_event_loop().time() < deadline:
+            rows = await self._list_memory_rows(max_records=200)
+            if any(
+                str((row.get("metadata") or {}).get("memory_id") or "").strip()
+                == wanted_memory_id
+                for row in rows
+            ):
+                return
+            await asyncio.sleep(0.4)
+
+    async def query(self, query: str, *, limit: int = 50) -> MemoryQueryResult:
+        query_terms = [term for term in str(query or "").lower().split() if term]
+        row_limit = max(1, int(limit or 50))
+        rows = await self._list_memory_rows(max_records=max(200, row_limit * 10))
+        scored: list[tuple[int, str, dict[str, Any]]] = []
+        for row in rows:
+            metadata = dict(row.get("metadata") or {})
+            row_user = str(metadata.get("user_id") or "").strip()
+            if row_user and row_user != self._user_id:
+                continue
+            blob = (
+                str(row.get("content") or "")
+                + " "
+                + json.dumps(metadata, ensure_ascii=True, sort_keys=True)
+            ).lower()
+            score = 0
+            for term in query_terms:
+                if term in blob:
+                    score += 1
+            scored.append((score, str(metadata.get("updated_at") or ""), row))
+        scored.sort(key=lambda item: (-item[0], item[1]), reverse=False)
+        results: list[MemoryContent] = []
+        for _, _, row in scored[:row_limit]:
+            results.append(
+                MemoryContent(
+                    content=str(row.get("content") or ""),
+                    mime_type=str(row.get("mime_type") or "text/plain"),
+                    metadata=dict(row.get("metadata") or {}),
+                )
+            )
+        return MemoryQueryResult(results=results)
+
+    async def close(self) -> None:
+        await self._workbench.stop()
+
+
 class GraphitiConstraintMemoryClient(Mem0ConstraintMemoryClient):
-    """Graphiti backend using the durable constraint contract."""
+    """Graphiti backend using Graphiti MCP with durable constraint contract."""
 
     def __init__(
         self,
         *,
         user_id: str,
         limit: int = 200,
-        is_cloud: bool = False,
-        api_key: str | None = None,
-        local_config: dict[str, Any] | None = None,
-        cloud_url: str = "",
+        server_url: str,
+        group_id: str,
+        timeout_s: float,
     ) -> None:
+        backend = _GraphitiMcpMemoryBackend(
+            server_url=server_url,
+            group_id=group_id,
+            user_id=user_id,
+            timeout_s=timeout_s,
+        )
         super().__init__(
             user_id=user_id,
             limit=limit,
-            is_cloud=is_cloud,
-            api_key=api_key,
-            local_config=local_config,
+            is_cloud=False,
+            local_config=None,
+            memory_backend=backend,
         )
-        self._graphiti_is_cloud = bool(is_cloud)
-        self._graphiti_cloud_url = str(cloud_url or "").strip()
-        self._graphiti_local_config = dict(local_config or {})
+        self._graphiti_server_url = server_url
+        self._graphiti_group_id = group_id
+        self._graphiti_timeout_s = timeout_s
 
     async def get_store_info(self) -> dict[str, Any]:
         info = {
             "backend": "graphiti",
             "user_id": self._user_id,
             "limit": self._limit,
-            "is_cloud": self._graphiti_is_cloud,
+            "mcp_server_url": self._graphiti_server_url,
+            "group_id": self._graphiti_group_id,
+            "timeout_s": self._graphiti_timeout_s,
         }
-        if self._graphiti_is_cloud:
-            if self._graphiti_cloud_url:
-                info["cloud_url"] = self._graphiti_cloud_url
-        elif self._graphiti_local_config:
-            info["local_config_keys"] = sorted(self._graphiti_local_config.keys())
+        try:
+            status_fn = getattr(self._memory, "status", None)
+            if callable(status_fn):
+                status = await status_fn()
+                if isinstance(status, dict):
+                    info["status"] = status
+        except Exception as exc:
+            info["status_error"] = f"{type(exc).__name__}: {exc}"
         return info
 
     async def upsert_constraint(
@@ -65,20 +280,20 @@ class GraphitiConstraintMemoryClient(Mem0ConstraintMemoryClient):
 
 def build_graphiti_client_from_settings(*, user_id: str) -> GraphitiConstraintMemoryClient:
     """Create a Graphiti constraint client from application settings."""
-    local_config_raw = (
-        getattr(settings, "graphiti_local_config_json", "") or ""
-    ).strip()
-    local_config = json.loads(local_config_raw) if local_config_raw else None
-    is_cloud = bool(getattr(settings, "graphiti_is_cloud", False))
-    api_key = (getattr(settings, "graphiti_api_key", "") or "").strip() or None
-    cloud_url = (getattr(settings, "graphiti_cloud_url", "") or "").strip()
+    server_url = str(getattr(settings, "graphiti_mcp_server_url", "") or "").strip()
+    if not server_url:
+        raise ValueError("GRAPHITI_MCP_SERVER_URL is required for graphiti backend")
+    group_id = (
+        str(getattr(settings, "graphiti_mcp_group_id", "") or "").strip()
+        or "timeboxing"
+    )
+    timeout_s = float(getattr(settings, "graphiti_mcp_timeout_seconds", 15.0) or 15.0)
     return GraphitiConstraintMemoryClient(
         user_id=user_id,
         limit=int(getattr(settings, "graphiti_query_limit", 200) or 200),
-        is_cloud=is_cloud,
-        api_key=api_key,
-        local_config=local_config,
-        cloud_url=cloud_url,
+        server_url=server_url,
+        group_id=group_id,
+        timeout_s=timeout_s,
     )
 
 

--- a/src/fateforger/agents/timeboxing/nlu.py
+++ b/src/fateforger/agents/timeboxing/nlu.py
@@ -128,6 +128,9 @@ You are Schedular, interpreting whether a message contains explicit scheduling c
 Task
 - Interpret the user message in ANY language.
 - Output STRICT JSON matching ConstraintInterpretation.
+- The input payload is JSON with:
+  - text, is_initial, planned_date, timezone, stage_id
+  - existing_constraints: currently active session constraints in this thread
 
 Definitions
 - should_extract: true only if the user explicitly states a scheduling constraint or preference as THEIR own.
@@ -142,6 +145,9 @@ Rules
 - Default to scope=session unless the user explicitly indicates durable or bounded-period intent.
 - Return constraints=[] if should_extract=false.
 - If scope=datespan, include start_date/end_date as ISO dates if the user provided enough info; otherwise keep them null.
+- If scope=session and should_extract=true: return the complete updated session-constraint set,
+  not just deltas. Keep unchanged existing constraints, update conflicting ones, and add new ones.
+- User's latest message has precedence over conflicting existing_constraints.
 
 Aspect classification (REQUIRED for every extracted constraint)
 For every constraint in the constraints list, always set hints.aspect_classification to a JSON

--- a/src/fateforger/agents/timeboxing/preferences.py
+++ b/src/fateforger/agents/timeboxing/preferences.py
@@ -238,6 +238,50 @@ class ConstraintStore:
                     await session.refresh(row)
             return {"added": len(to_add), "skipped": skipped, "total": len(constraints)}
 
+    async def replace_session_constraints(
+        self,
+        *,
+        user_id: str,
+        channel_id: Optional[str],
+        thread_ts: Optional[str],
+        constraints: List[ConstraintBase],
+    ) -> List[Constraint]:
+        """Replace session-scope constraints for one thread with a full updated set."""
+        if not thread_ts:
+            return []
+        session_constraints = [
+            constraint
+            for constraint in constraints
+            if (constraint.scope or ConstraintScope.SESSION) == ConstraintScope.SESSION
+        ]
+        rows = [
+            _constraint_row(
+                constraint,
+                user_id=user_id,
+                channel_id=channel_id,
+                thread_ts=thread_ts,
+            )
+            for constraint in session_constraints
+        ]
+        async with self._sessionmaker() as session:
+            stmt = select(Constraint).where(
+                Constraint.user_id == user_id,
+                Constraint.scope == ConstraintScope.SESSION,
+                Constraint.thread_ts == thread_ts,
+            )
+            if channel_id:
+                stmt = stmt.where(Constraint.channel_id == channel_id)
+            result = await session.execute(stmt)
+            existing = list(result.scalars().all())
+            for row in existing:
+                await session.delete(row)
+            if rows:
+                session.add_all(rows)
+            await session.commit()
+            for row in rows:
+                await session.refresh(row)
+            return rows
+
     async def list_constraints(
         self,
         *,

--- a/src/fateforger/core/README.md
+++ b/src/fateforger/core/README.md
@@ -1,3 +1,7 @@
 # core
 
 Runtime startup logs include git provenance fields (`branch`, `commit`, `tag`, `dirty`) to help correlate observed behavior with the exact running code revision.
+
+Startup now performs explicit dependency gates before agent runtime creation:
+- required MCP endpoint discovery (`calendar-mcp` mandatory; optional endpoints logged as warnings), and
+- Graphiti runtime readiness when any configured backend path requires Graphiti.

--- a/src/fateforger/core/config.py
+++ b/src/fateforger/core/config.py
@@ -1,3 +1,4 @@
+import json
 import os
 import sys
 from urllib.parse import urlparse
@@ -389,15 +390,40 @@ class Settings(BaseSettings):
                     "Mem0 backend requires MEM0_LOCAL_CONFIG_JSON or "
                     "(MEM0_IS_CLOUD=1 + MEM0_API_KEY)."
                 )
-        if self.timeboxing_memory_backend == "graphiti" and self.graphiti_is_cloud:
-            has_cloud_runtime = bool(
-                self.graphiti_api_key.strip() and self.graphiti_cloud_url.strip()
-            )
-            if not has_cloud_runtime:
-                raise ValueError(
-                    "Graphiti cloud backend requires GRAPHITI_API_KEY and "
-                    "GRAPHITI_CLOUD_URL when GRAPHITI_IS_CLOUD=1."
+        if self.timeboxing_memory_backend == "graphiti":
+            if self.graphiti_is_cloud:
+                has_cloud_runtime = bool(
+                    self.graphiti_api_key.strip() and self.graphiti_cloud_url.strip()
                 )
+                if not has_cloud_runtime:
+                    raise ValueError(
+                        "Graphiti cloud backend requires GRAPHITI_API_KEY and "
+                        "GRAPHITI_CLOUD_URL when GRAPHITI_IS_CLOUD=1."
+                    )
+            else:
+                local_config_raw = (self.graphiti_local_config_json or "").strip()
+                if not local_config_raw:
+                    raise ValueError(
+                        "Graphiti local backend requires GRAPHITI_LOCAL_CONFIG_JSON "
+                        "to point at a DB-backed runtime config."
+                    )
+                try:
+                    local_config = json.loads(local_config_raw)
+                except Exception as exc:
+                    raise ValueError(
+                        "GRAPHITI_LOCAL_CONFIG_JSON must be valid JSON."
+                    ) from exc
+                if not isinstance(local_config, dict):
+                    raise ValueError(
+                        "GRAPHITI_LOCAL_CONFIG_JSON must decode to a JSON object."
+                    )
+                # Guard against the deprecated JSON file fallback artifact mode.
+                local_path = str(local_config.get("path") or "").strip().lower()
+                if local_path.endswith(".json"):
+                    raise ValueError(
+                        "Graphiti local config path must not target a JSON file "
+                        "(for example graphiti_memory.json). Use a DB-backed runtime."
+                    )
         return self
 
 

--- a/src/fateforger/core/config.py
+++ b/src/fateforger/core/config.py
@@ -1,4 +1,3 @@
-import json
 import os
 import sys
 from urllib.parse import urlparse
@@ -29,13 +28,9 @@ class Settings(BaseSettings):
     slack_app_token: str = Field(default="your_slack_app_token_here")
     slack_socket_mode: bool = Field(default=True)
     slack_port: int = Field(default=3000)
-    slack_focus_ttl_seconds: int = Field(
-        default=60 * 60
-    )
+    slack_focus_ttl_seconds: int = Field(default=60 * 60)
     slack_app_name: str = Field(default="FateForger")
-    slack_timeboxing_channel_id: str = Field(
-        default=""
-    )
+    slack_timeboxing_channel_id: str = Field(default="")
     slack_strategy_channel_id: str = Field(default="")
     slack_tasks_channel_id: str = Field(default="")
     slack_ops_channel_id: str = Field(default="")
@@ -53,68 +48,38 @@ class Settings(BaseSettings):
     # LLM Provider Configuration
     # - "openai": OpenAI-hosted models via https://api.openai.com/v1
     # - "openrouter": OpenRouter OpenAI-compatible endpoint via https://openrouter.ai/api/v1
-    llm_provider: str = Field(default="openai")
+    llm_provider: str = Field(default="openrouter")
     openrouter_api_key: str = Field(default="")
-    openrouter_base_url: str = Field(
-        default="https://openrouter.ai/api/v1"
-    )
+    openrouter_base_url: str = Field(default="https://openrouter.ai/api/v1")
     openrouter_http_referer: str = Field(default="")
     openrouter_title: str = Field(default="FateForger")
-    openrouter_send_reasoning_effort_header: bool = Field(
-        default=False
-    )
-    openrouter_reasoning_effort_header: str = Field(
-        default="X-Reasoning-Effort"
-    )
-    openrouter_default_model_flash: str = Field(
-        default="google/gemini-3-flash-preview"
-    )
-    openrouter_default_model_pro: str = Field(
-        default="google/gemini-3-flash-preview"
-    )
+    openrouter_send_reasoning_effort_header: bool = Field(default=False)
+    openrouter_reasoning_effort_header: str = Field(default="X-Reasoning-Effort")
+    openrouter_default_model_flash: str = Field(default="google/gemini-3-flash-preview")
+    openrouter_default_model_pro: str = Field(default="google/gemini-3-flash-preview")
 
     # Per-agent model selection (optional; provider-specific model IDs)
     llm_model_receptionist: str = Field(default="")
     llm_model_admonisher: str = Field(default="")
     llm_model_timeboxing: str = Field(default="")
-    llm_model_timeboxing_draft: str = Field(
-        default=""
-    )
-    llm_model_timebox_patcher: str = Field(
-        default=""
-    )
+    llm_model_timeboxing_draft: str = Field(default="")
+    llm_model_timebox_patcher: str = Field(default="")
     llm_model_planner: str = Field(default="")
     llm_model_revisor: str = Field(default="")
     llm_model_tasks: str = Field(default="")
-    llm_model_calendar_submitter: str = Field(
-        default=""
-    )
+    llm_model_calendar_submitter: str = Field(default="")
 
     # Per-agent temperature
-    llm_temperature_admonisher: float = Field(
-        default=1.1
-    )
+    llm_temperature_admonisher: float = Field(default=1.1)
 
     # Per-agent reasoning effort (OpenRouter: request body `reasoning.effort`; "low"|"medium"|"high")
-    llm_reasoning_effort_timeboxing: str = Field(
-        default=""
-    )
-    llm_reasoning_effort_timeboxing_draft: str = Field(
-        default=""
-    )
-    llm_reasoning_effort_revisor: str = Field(
-        default=""
-    )
-    llm_reasoning_effort_tasks: str = Field(
-        default=""
-    )
-    llm_reasoning_effort_timebox_patcher: str = Field(
-        default=""
-    )
+    llm_reasoning_effort_timeboxing: str = Field(default="")
+    llm_reasoning_effort_timeboxing_draft: str = Field(default="")
+    llm_reasoning_effort_revisor: str = Field(default="")
+    llm_reasoning_effort_tasks: str = Field(default="")
+    llm_reasoning_effort_timebox_patcher: str = Field(default="")
     llm_max_tokens: int = Field(default=0)
-    llm_max_tokens_timebox_patcher: int = Field(
-        default=0
-    )
+    llm_max_tokens_timebox_patcher: int = Field(default=0)
 
     # MCP Server Configuration
     mcp_version: str = Field(default="v1.4.8")
@@ -123,18 +88,10 @@ class Settings(BaseSettings):
     google_oauth_credentials: str = Field(default="/app/gcp-oauth.keys.json")
     mcp_http_port: str = Field(default="3001")
     mcp_http_auth_token: str = Field(default="change_me_to_a_long_random_secret")
-    mcp_calendar_server_url: str = Field(
-        default="http://localhost:3000"
-    )
-    mcp_calendar_server_url_docker: str = Field(
-        default="http://calendar-mcp:3000"
-    )
-    notion_mcp_url: str = Field(
-        default="http://localhost:3001/mcp"
-    )
-    ticktick_mcp_url: str = Field(
-        default="http://ticktick-mcp:8000/mcp"
-    )
+    mcp_calendar_server_url: str = Field(default="http://localhost:3000")
+    mcp_calendar_server_url_docker: str = Field(default="http://calendar-mcp:3000")
+    notion_mcp_url: str = Field(default="http://localhost:3001/mcp")
+    ticktick_mcp_url: str = Field(default="http://ticktick-mcp:8000/mcp")
 
     # TickTick Configuration
     ticktick_mcp_version: str = Field(default="main")
@@ -148,17 +105,11 @@ class Settings(BaseSettings):
     # Notion Configuration
     notion_token: str = Field(default="")
     work_notion_token: str = Field(default="")
-    notion_timeboxing_parent_page_id: str = Field(
-        default=""
-    )
+    notion_timeboxing_parent_page_id: str = Field(default="")
     notion_sprint_db_id: str = Field(default="")
-    notion_sprint_data_source_url: str = Field(
-        default=""
-    )
+    notion_sprint_data_source_url: str = Field(default="")
     notion_sprint_db_ids: str = Field(default="")
-    notion_sprint_data_source_urls: str = Field(
-        default=""
-    )
+    notion_sprint_data_source_urls: str = Field(default="")
 
     # Database Configuration
     alembic_database_url: str = Field(default="sqlite:///data/admonish.db")
@@ -181,20 +132,14 @@ class Settings(BaseSettings):
     wizard_session_secret: str = Field(default="")
 
     # Agent runtime timeouts (seconds)
-    agent_on_messages_timeout_seconds: int = Field(
-        default=60
-    )
-    agent_mcp_discovery_timeout_seconds: int = Field(
-        default=10
-    )
+    agent_on_messages_timeout_seconds: int = Field(default=60)
+    agent_mcp_discovery_timeout_seconds: int = Field(default=10)
     slack_register_user_timeout_seconds: float = Field(default=3.0, gt=0.0)
     slack_route_dispatch_timeout_seconds: float = Field(default=75.0, gt=0.0)
 
     # Timeboxing feature flags
-    timeboxing_memory_backend: str = Field(
-        default="constraint_mcp"
-    )
-    tasks_defaults_memory_backend: str = Field(default="constraint_mcp")
+    timeboxing_memory_backend: str = Field(default="graphiti")
+    tasks_defaults_memory_backend: str = Field(default="graphiti")
 
     # Legacy Mem0 Memory Configuration (deprecated)
     mem0_user_id: str = Field(default="timeboxing")
@@ -205,10 +150,9 @@ class Settings(BaseSettings):
 
     # Graphiti Memory Configuration
     graphiti_user_id: str = Field(default="timeboxing")
-    graphiti_is_cloud: bool = Field(default=False)
-    graphiti_api_key: str = Field(default="")
-    graphiti_cloud_url: str = Field(default="")
-    graphiti_local_config_json: str = Field(default="")
+    graphiti_mcp_server_url: str = Field(default="http://localhost:8005/mcp")
+    graphiti_mcp_group_id: str = Field(default="timeboxing")
+    graphiti_mcp_timeout_seconds: float = Field(default=15.0, gt=0.0)
     graphiti_query_limit: int = Field(default=200)
 
     # Observability Configuration
@@ -218,7 +162,9 @@ class Settings(BaseSettings):
     obs_llm_audit_sink: str = Field(default="loki")
     obs_llm_audit_mode: str = Field(default="sanitized")
     obs_llm_audit_max_chars: int = Field(default=2000)
-    obs_llm_audit_loki_url: str = Field(default="http://localhost:3100/loki/api/v1/push")
+    obs_llm_audit_loki_url: str = Field(
+        default="http://localhost:3100/loki/api/v1/push"
+    )
     obs_llm_audit_queue_max: int = Field(default=4096, ge=1, le=200000)
     obs_llm_audit_batch_size: int = Field(default=128, ge=1, le=10000)
     obs_llm_audit_flush_interval_ms: int = Field(default=250, ge=10, le=60000)
@@ -248,7 +194,7 @@ class Settings(BaseSettings):
             "MCP calendar URL must be absolute and start with http:// or https://"
         )
 
-    @field_validator("notion_mcp_url", "ticktick_mcp_url")
+    @field_validator("notion_mcp_url", "ticktick_mcp_url", "graphiti_mcp_server_url")
     @classmethod
     def _validate_mcp_tool_endpoint_url(cls, value: str) -> str:
         parsed = urlparse((value or "").strip())
@@ -273,21 +219,20 @@ class Settings(BaseSettings):
     @classmethod
     def _validate_timeboxing_memory_backend(cls, value: str) -> str:
         backend = (value or "").strip().lower()
-        if backend in {"constraint_mcp", "graphiti"}:
+        if backend == "graphiti":
             return backend
         raise ValueError(
-            "TIMEBOXING_MEMORY_BACKEND must be one of: constraint_mcp, graphiti"
+            "TIMEBOXING_MEMORY_BACKEND must be: graphiti"
         )
 
     @field_validator("tasks_defaults_memory_backend")
     @classmethod
     def _validate_tasks_defaults_memory_backend(cls, value: str) -> str:
         backend = (value or "").strip().lower()
-        if backend in {"constraint_mcp", "mem0", "disabled", "inherit_timeboxing"}:
+        if backend == "graphiti":
             return backend
         raise ValueError(
-            "TASKS_DEFAULTS_MEMORY_BACKEND must be one of: "
-            "constraint_mcp, mem0, disabled, inherit_timeboxing"
+            "TASKS_DEFAULTS_MEMORY_BACKEND must be: graphiti"
         )
 
     @field_validator("autogen_events_log")
@@ -313,9 +258,7 @@ class Settings(BaseSettings):
         target = (value or "").strip().lower()
         if target in {"stdout", "audit"}:
             return target
-        raise ValueError(
-            "AUTOGEN_EVENTS_OUTPUT_TARGET must be one of: stdout, audit"
-        )
+        raise ValueError("AUTOGEN_EVENTS_OUTPUT_TARGET must be one of: stdout, audit")
 
     @field_validator("autogen_events_full_payload_mode")
     @classmethod
@@ -357,73 +300,12 @@ class Settings(BaseSettings):
             )
         return value
 
-    @field_validator("graphiti_cloud_url")
-    @classmethod
-    def _validate_graphiti_cloud_url(cls, value: str) -> str:
-        text = (value or "").strip()
-        if not text:
-            return ""
-        parsed = urlparse(text)
-        if parsed.scheme not in {"http", "https"} or not parsed.netloc:
-            raise ValueError(
-                "GRAPHITI_CLOUD_URL must be absolute and start with http:// or https://"
-            )
-        return text
-
     @model_validator(mode="after")
     def _validate_runtime_invariants(self) -> "Settings":
         if not self.slack_socket_mode:
             raise ValueError("SLACK_SOCKET_MODE must remain enabled")
-        needs_mem0_runtime = self.timeboxing_memory_backend == "mem0" or (
-            self.tasks_defaults_memory_backend == "mem0"
-        )
-        if self.tasks_defaults_memory_backend == "inherit_timeboxing":
-            needs_mem0_runtime = needs_mem0_runtime or (
-                self.timeboxing_memory_backend == "mem0"
-            )
-        if needs_mem0_runtime:
-            local_config = (self.mem0_local_config_json or "").strip()
-            has_local_runtime = bool(local_config)
-            has_cloud_runtime = bool(self.mem0_is_cloud and self.mem0_api_key.strip())
-            if not (has_local_runtime or has_cloud_runtime):
-                raise ValueError(
-                    "Mem0 backend requires MEM0_LOCAL_CONFIG_JSON or "
-                    "(MEM0_IS_CLOUD=1 + MEM0_API_KEY)."
-                )
-        if self.timeboxing_memory_backend == "graphiti":
-            if self.graphiti_is_cloud:
-                has_cloud_runtime = bool(
-                    self.graphiti_api_key.strip() and self.graphiti_cloud_url.strip()
-                )
-                if not has_cloud_runtime:
-                    raise ValueError(
-                        "Graphiti cloud backend requires GRAPHITI_API_KEY and "
-                        "GRAPHITI_CLOUD_URL when GRAPHITI_IS_CLOUD=1."
-                    )
-            else:
-                local_config_raw = (self.graphiti_local_config_json or "").strip()
-                if not local_config_raw:
-                    raise ValueError(
-                        "Graphiti local backend requires GRAPHITI_LOCAL_CONFIG_JSON "
-                        "to point at a DB-backed runtime config."
-                    )
-                try:
-                    local_config = json.loads(local_config_raw)
-                except Exception as exc:
-                    raise ValueError(
-                        "GRAPHITI_LOCAL_CONFIG_JSON must be valid JSON."
-                    ) from exc
-                if not isinstance(local_config, dict):
-                    raise ValueError(
-                        "GRAPHITI_LOCAL_CONFIG_JSON must decode to a JSON object."
-                    )
-                # Guard against the deprecated JSON file fallback artifact mode.
-                local_path = str(local_config.get("path") or "").strip().lower()
-                if local_path.endswith(".json"):
-                    raise ValueError(
-                        "Graphiti local config path must not target a JSON file "
-                        "(for example graphiti_memory.json). Use a DB-backed runtime."
-                    )
+        if not (self.graphiti_mcp_server_url or "").strip():
+            raise ValueError("Graphiti backend requires GRAPHITI_MCP_SERVER_URL.")
         return self
 
 

--- a/src/fateforger/core/runtime.py
+++ b/src/fateforger/core/runtime.py
@@ -259,16 +259,8 @@ async def _assert_mcp_servers_available() -> None:
 
 
 def _graphiti_backend_required() -> bool:
-    """Return whether any configured runtime path requires Graphiti availability."""
-    timeboxing_backend = str(
-        getattr(settings, "timeboxing_memory_backend", "") or ""
-    ).strip().lower()
-    tasks_backend = str(
-        getattr(settings, "tasks_defaults_memory_backend", "") or ""
-    ).strip().lower()
-    if tasks_backend == "inherit_timeboxing":
-        tasks_backend = timeboxing_backend
-    return timeboxing_backend == "graphiti" or tasks_backend == "graphiti"
+    """Graphiti is the single durable-memory backend and always required."""
+    return True
 
 
 async def _assert_graphiti_runtime_available() -> None:
@@ -298,9 +290,9 @@ async def _assert_graphiti_runtime_available() -> None:
             f"{type(exc).__name__}: {exc}"
         ) from exc
     logger.info(
-        "Graphiti startup dependency check passed (backend=%s, is_cloud=%s)",
+        "Graphiti startup dependency check passed (backend=%s, mcp_server_url=%s)",
         str(info.get("backend") or "unknown"),
-        bool(info.get("is_cloud")),
+        str(info.get("mcp_server_url") or "unknown"),
     )
 
 

--- a/src/fateforger/core/runtime.py
+++ b/src/fateforger/core/runtime.py
@@ -1,20 +1,13 @@
 import asyncio
 import logging
-import os
 import subprocess
 from dataclasses import dataclass
 from pathlib import Path
-from typing import Callable
 
 from apscheduler.schedulers.asyncio import AsyncIOScheduler
 from autogen_core import (
     AgentId,
-    DefaultTopicId,
-    MessageContext,
-    RoutedAgent,
     SingleThreadedAgentRuntime,
-    default_subscription,
-    message_handler,
 )
 from autogen_core.tool_agent import ToolAgent
 from sqlalchemy.ext.asyncio import async_sessionmaker, create_async_engine
@@ -265,6 +258,52 @@ async def _assert_mcp_servers_available() -> None:
     logger.info("MCP startup dependency checks passed (%s)", summary)
 
 
+def _graphiti_backend_required() -> bool:
+    """Return whether any configured runtime path requires Graphiti availability."""
+    timeboxing_backend = str(
+        getattr(settings, "timeboxing_memory_backend", "") or ""
+    ).strip().lower()
+    tasks_backend = str(
+        getattr(settings, "tasks_defaults_memory_backend", "") or ""
+    ).strip().lower()
+    if tasks_backend == "inherit_timeboxing":
+        tasks_backend = timeboxing_backend
+    return timeboxing_backend == "graphiti" or tasks_backend == "graphiti"
+
+
+async def _assert_graphiti_runtime_available() -> None:
+    """Fail fast when Graphiti is configured but runtime dependencies are unavailable."""
+    if not _graphiti_backend_required():
+        return
+    try:
+        from fateforger.agents.timeboxing.durable_constraint_store import (
+            build_durable_constraint_store,
+        )
+        from fateforger.agents.timeboxing.graphiti_constraint_memory import (
+            build_graphiti_client_from_settings,
+        )
+
+        user_id = (
+            str(getattr(settings, "graphiti_user_id", "") or "").strip()
+            or "timeboxing"
+        )
+        client = build_graphiti_client_from_settings(user_id=user_id)
+        store = build_durable_constraint_store(client)
+        info = await store.get_store_info()
+        await store.query_constraints(filters={}, limit=1)
+    except Exception as exc:
+        raise RuntimeError(
+            "Graphiti startup dependency check failed. "
+            "Resolve Graphiti runtime configuration before starting the app. "
+            f"{type(exc).__name__}: {exc}"
+        ) from exc
+    logger.info(
+        "Graphiti startup dependency check passed (backend=%s, is_cloud=%s)",
+        str(info.get("backend") or "unknown"),
+        bool(info.get("is_cloud")),
+    )
+
+
 async def _run_initial_planning_reconcile(
     *,
     planning_guardian: PlanningGuardian,
@@ -311,6 +350,7 @@ async def _create_runtime() -> SingleThreadedAgentRuntime:
         git_identity.dirty,
     )
     await _assert_mcp_servers_available()
+    await _assert_graphiti_runtime_available()
     scheduler = _create_scheduler(settings.database_url)
     scheduler.start()
 

--- a/tests/unit/test_runtime_mcp_startup_checks.py
+++ b/tests/unit/test_runtime_mcp_startup_checks.py
@@ -237,13 +237,13 @@ def test_graphiti_backend_required_when_timeboxing_backend_is_graphiti(
     monkeypatch.setattr(
         runtime_module.settings,
         "tasks_defaults_memory_backend",
-        "constraint_mcp",
+        "graphiti",
         raising=False,
     )
     assert runtime_module._graphiti_backend_required() is True  # noqa: SLF001
 
 
-def test_graphiti_backend_required_when_tasks_inherit_graphiti(
+def test_graphiti_backend_required_when_tasks_backend_is_graphiti(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     monkeypatch.setattr(
@@ -252,7 +252,7 @@ def test_graphiti_backend_required_when_tasks_inherit_graphiti(
     monkeypatch.setattr(
         runtime_module.settings,
         "tasks_defaults_memory_backend",
-        "inherit_timeboxing",
+        "graphiti",
         raising=False,
     )
     assert runtime_module._graphiti_backend_required() is True  # noqa: SLF001
@@ -275,7 +275,10 @@ async def test_assert_graphiti_runtime_available_passes_with_queryable_store(
 
     class _Store:
         async def get_store_info(self) -> dict[str, object]:
-            return {"backend": "graphiti", "is_cloud": False}
+            return {
+                "backend": "graphiti",
+                "mcp_server_url": "http://localhost:8005/mcp",
+            }
 
         async def query_constraints(self, *, filters, limit):  # noqa: ANN001
             assert isinstance(filters, dict)

--- a/tests/unit/test_runtime_mcp_startup_checks.py
+++ b/tests/unit/test_runtime_mcp_startup_checks.py
@@ -226,3 +226,91 @@ async def test_assert_mcp_servers_available_required_failure_still_raises(
     assert "calendar-mcp" in message
     # optional server should NOT appear in the hard-failure message
     assert "notion-mcp" not in message
+
+
+def test_graphiti_backend_required_when_timeboxing_backend_is_graphiti(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(
+        runtime_module.settings, "timeboxing_memory_backend", "graphiti", raising=False
+    )
+    monkeypatch.setattr(
+        runtime_module.settings,
+        "tasks_defaults_memory_backend",
+        "constraint_mcp",
+        raising=False,
+    )
+    assert runtime_module._graphiti_backend_required() is True  # noqa: SLF001
+
+
+def test_graphiti_backend_required_when_tasks_inherit_graphiti(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(
+        runtime_module.settings, "timeboxing_memory_backend", "graphiti", raising=False
+    )
+    monkeypatch.setattr(
+        runtime_module.settings,
+        "tasks_defaults_memory_backend",
+        "inherit_timeboxing",
+        raising=False,
+    )
+    assert runtime_module._graphiti_backend_required() is True  # noqa: SLF001
+
+
+async def test_assert_graphiti_runtime_available_noops_when_not_required(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(runtime_module, "_graphiti_backend_required", lambda: False)
+    await runtime_module._assert_graphiti_runtime_available()  # noqa: SLF001
+
+
+async def test_assert_graphiti_runtime_available_passes_with_queryable_store(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(runtime_module, "_graphiti_backend_required", lambda: True)
+
+    import fateforger.agents.timeboxing.durable_constraint_store as durable_store_mod
+    import fateforger.agents.timeboxing.graphiti_constraint_memory as graphiti_mod
+
+    class _Store:
+        async def get_store_info(self) -> dict[str, object]:
+            return {"backend": "graphiti", "is_cloud": False}
+
+        async def query_constraints(self, *, filters, limit):  # noqa: ANN001
+            assert isinstance(filters, dict)
+            assert limit == 1
+            return []
+
+    monkeypatch.setattr(
+        graphiti_mod,
+        "build_graphiti_client_from_settings",
+        lambda *, user_id: object(),
+    )
+    monkeypatch.setattr(
+        durable_store_mod,
+        "build_durable_constraint_store",
+        lambda _client: _Store(),
+    )
+
+    await runtime_module._assert_graphiti_runtime_available()  # noqa: SLF001
+
+
+async def test_assert_graphiti_runtime_available_raises_with_clear_message(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(runtime_module, "_graphiti_backend_required", lambda: True)
+
+    import fateforger.agents.timeboxing.graphiti_constraint_memory as graphiti_mod
+
+    def _boom(*, user_id: str) -> object:
+        raise RuntimeError("graphiti runtime unavailable")
+
+    monkeypatch.setattr(graphiti_mod, "build_graphiti_client_from_settings", _boom)
+
+    with pytest.raises(RuntimeError) as exc_info:
+        await runtime_module._assert_graphiti_runtime_available()  # noqa: SLF001
+
+    message = str(exc_info.value)
+    assert "Graphiti startup dependency check failed" in message
+    assert "graphiti runtime unavailable" in message

--- a/tests/unit/test_settings_mcp_endpoints.py
+++ b/tests/unit/test_settings_mcp_endpoints.py
@@ -69,44 +69,60 @@ def test_settings_rejects_unknown_timeboxing_memory_backend(monkeypatch) -> None
         Settings()
 
 
-def test_settings_rejects_graphiti_cloud_without_runtime_config(monkeypatch) -> None:
-    monkeypatch.setenv("TIMEBOXING_MEMORY_BACKEND", "graphiti")
-    monkeypatch.setenv("GRAPHITI_IS_CLOUD", "true")
-    monkeypatch.delenv("GRAPHITI_API_KEY", raising=False)
-    monkeypatch.delenv("GRAPHITI_CLOUD_URL", raising=False)
+def test_settings_rejects_constraint_mcp_timeboxing_memory_backend(monkeypatch) -> None:
+    monkeypatch.setenv("TIMEBOXING_MEMORY_BACKEND", "constraint_mcp")
     with pytest.raises(ValueError):
         Settings()
 
 
-def test_settings_accepts_graphiti_with_local_runtime_config(monkeypatch) -> None:
+def test_settings_rejects_graphiti_without_mcp_url(monkeypatch) -> None:
     monkeypatch.setenv("TIMEBOXING_MEMORY_BACKEND", "graphiti")
-    monkeypatch.setenv("GRAPHITI_IS_CLOUD", "false")
-    monkeypatch.setenv(
-        "GRAPHITI_LOCAL_CONFIG_JSON", "{\"path\":\"./data/graphiti\"}"
-    )
+    monkeypatch.setenv("GRAPHITI_MCP_SERVER_URL", "")
+    with pytest.raises(ValueError):
+        Settings()
+
+
+def test_settings_accepts_graphiti_with_mcp_runtime_config(monkeypatch) -> None:
+    monkeypatch.setenv("TIMEBOXING_MEMORY_BACKEND", "graphiti")
+    monkeypatch.setenv("GRAPHITI_MCP_SERVER_URL", "http://localhost:8005/mcp")
     settings = Settings()
     assert settings.timeboxing_memory_backend == "graphiti"
 
 
-def test_settings_rejects_graphiti_local_json_file_fallback(monkeypatch) -> None:
+def test_settings_rejects_invalid_graphiti_mcp_url(monkeypatch) -> None:
     monkeypatch.setenv("TIMEBOXING_MEMORY_BACKEND", "graphiti")
-    monkeypatch.setenv("GRAPHITI_IS_CLOUD", "false")
-    monkeypatch.setenv(
-        "GRAPHITI_LOCAL_CONFIG_JSON", "{\"path\":\"./data/graphiti_memory.json\"}"
-    )
+    monkeypatch.setenv("GRAPHITI_MCP_SERVER_URL", "graphiti-mcp:8000")
     with pytest.raises(ValueError):
         Settings()
 
 
-def test_settings_accepts_graphiti_cloud_with_required_fields(
+def test_settings_accepts_tasks_defaults_graphiti_backend(monkeypatch) -> None:
+    monkeypatch.setenv("TASKS_DEFAULTS_MEMORY_BACKEND", "graphiti")
+    monkeypatch.setenv("GRAPHITI_MCP_SERVER_URL", "http://localhost:8005/mcp")
+    settings = Settings()
+    assert settings.tasks_defaults_memory_backend == "graphiti"
+
+
+def test_settings_rejects_tasks_defaults_graphiti_without_mcp_url(monkeypatch) -> None:
+    monkeypatch.setenv("TIMEBOXING_MEMORY_BACKEND", "graphiti")
+    monkeypatch.setenv("TASKS_DEFAULTS_MEMORY_BACKEND", "graphiti")
+    monkeypatch.setenv("GRAPHITI_MCP_SERVER_URL", "")
+    with pytest.raises(ValueError):
+        Settings()
+
+
+@pytest.mark.parametrize(
+    "legacy_backend",
+    ["mem0", "constraint_mcp", "inherit_timeboxing", "disabled"],
+)
+def test_settings_rejects_non_graphiti_tasks_defaults_backend(
     monkeypatch,
+    legacy_backend: str,
 ) -> None:
     monkeypatch.setenv("TIMEBOXING_MEMORY_BACKEND", "graphiti")
-    monkeypatch.setenv("GRAPHITI_IS_CLOUD", "true")
-    monkeypatch.setenv("GRAPHITI_API_KEY", "gk_test")
-    monkeypatch.setenv("GRAPHITI_CLOUD_URL", "https://graphiti.example.com")
-    settings = Settings()
-    assert settings.timeboxing_memory_backend == "graphiti"
+    monkeypatch.setenv("TASKS_DEFAULTS_MEMORY_BACKEND", legacy_backend)
+    with pytest.raises(ValueError):
+        Settings()
 
 
 def test_settings_rejects_invalid_notion_mcp_url(monkeypatch) -> None:

--- a/tests/unit/test_settings_mcp_endpoints.py
+++ b/tests/unit/test_settings_mcp_endpoints.py
@@ -82,10 +82,20 @@ def test_settings_accepts_graphiti_with_local_runtime_config(monkeypatch) -> Non
     monkeypatch.setenv("TIMEBOXING_MEMORY_BACKEND", "graphiti")
     monkeypatch.setenv("GRAPHITI_IS_CLOUD", "false")
     monkeypatch.setenv(
-        "GRAPHITI_LOCAL_CONFIG_JSON", "{\"path\":\"./data/graphiti_memory.json\"}"
+        "GRAPHITI_LOCAL_CONFIG_JSON", "{\"path\":\"./data/graphiti\"}"
     )
     settings = Settings()
     assert settings.timeboxing_memory_backend == "graphiti"
+
+
+def test_settings_rejects_graphiti_local_json_file_fallback(monkeypatch) -> None:
+    monkeypatch.setenv("TIMEBOXING_MEMORY_BACKEND", "graphiti")
+    monkeypatch.setenv("GRAPHITI_IS_CLOUD", "false")
+    monkeypatch.setenv(
+        "GRAPHITI_LOCAL_CONFIG_JSON", "{\"path\":\"./data/graphiti_memory.json\"}"
+    )
+    with pytest.raises(ValueError):
+        Settings()
 
 
 def test_settings_accepts_graphiti_cloud_with_required_fields(

--- a/tests/unit/test_task_defaults_memory.py
+++ b/tests/unit/test_task_defaults_memory.py
@@ -3,7 +3,10 @@ from __future__ import annotations
 import pytest
 
 import fateforger.agents.tasks.defaults_memory as defaults_memory_mod
-from fateforger.agents.tasks.defaults_memory import TaskDefaultsMemoryStore, TaskDueDefaults
+from fateforger.agents.tasks.defaults_memory import (
+    TaskDefaultsMemoryStore,
+    TaskDueDefaults,
+)
 from fateforger.core.config import settings
 
 
@@ -49,23 +52,27 @@ async def test_disk_fallback_persists_across_store_instances(
 def test_backend_selection_defaults_to_task_specific_setting(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    monkeypatch.setattr(settings, "timeboxing_memory_backend", "mem0", raising=False)
+    monkeypatch.setattr(
+        settings, "timeboxing_memory_backend", "graphiti", raising=False
+    )
+    monkeypatch.setattr(
+        settings, "tasks_defaults_memory_backend", "graphiti", raising=False
+    )
+    store = TaskDefaultsMemoryStore()
+    assert store._backend == "graphiti"
+
+
+def test_backend_selection_coerces_legacy_value_to_graphiti(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(
+        settings, "timeboxing_memory_backend", "graphiti", raising=False
+    )
     monkeypatch.setattr(
         settings, "tasks_defaults_memory_backend", "constraint_mcp", raising=False
     )
     store = TaskDefaultsMemoryStore()
-    assert store._backend == "constraint_mcp"
-
-
-def test_backend_selection_can_inherit_timeboxing_backend(
-    monkeypatch: pytest.MonkeyPatch,
-) -> None:
-    monkeypatch.setattr(settings, "timeboxing_memory_backend", "mem0", raising=False)
-    monkeypatch.setattr(
-        settings, "tasks_defaults_memory_backend", "inherit_timeboxing", raising=False
-    )
-    store = TaskDefaultsMemoryStore()
-    assert store._backend == "mem0"
+    assert store._backend == "graphiti"
 
 
 @pytest.mark.asyncio
@@ -73,11 +80,13 @@ async def test_missing_openai_key_falls_back_with_one_warning_per_user(
     monkeypatch: pytest.MonkeyPatch,
     caplog: pytest.LogCaptureFixture,
 ) -> None:
-    monkeypatch.setattr(settings, "tasks_defaults_memory_backend", "graphiti", raising=False)
+    monkeypatch.setattr(
+        settings, "tasks_defaults_memory_backend", "graphiti", raising=False
+    )
     monkeypatch.setattr(
         "fateforger.agents.tasks.defaults_memory.build_graphiti_client_from_settings",
         lambda user_id: (_ for _ in ()).throw(
-            RuntimeError("OPENAI_API_KEY is required for configured graphiti model")
+            RuntimeError("OPENROUTER_API_KEY is required for configured graphiti model")
         ),
     )
 
@@ -97,7 +106,7 @@ async def test_missing_openai_key_falls_back_with_one_warning_per_user(
         if "backend mode=fallback_cache" in rec.message
     ]
     assert len(warning_lines) == 2
-    assert all("reason_code=missing_openai_api_key" in msg for msg in warning_lines)
+    assert all("reason_code=missing_openrouter_api_key" in msg for msg in warning_lines)
 
 
 @pytest.mark.asyncio
@@ -106,7 +115,7 @@ async def test_durable_backend_logs_mode_once_and_reads_constraint(
     caplog: pytest.LogCaptureFixture,
 ) -> None:
     monkeypatch.setattr(
-        settings, "tasks_defaults_memory_backend", "constraint_mcp", raising=False
+        settings, "tasks_defaults_memory_backend", "graphiti", raising=False
     )
 
     class _Store:
@@ -158,7 +167,7 @@ async def test_runtime_durable_lookup_failure_downgrades_to_fallback_once(
     caplog: pytest.LogCaptureFixture,
 ) -> None:
     monkeypatch.setattr(
-        settings, "tasks_defaults_memory_backend", "constraint_mcp", raising=False
+        settings, "tasks_defaults_memory_backend", "graphiti", raising=False
     )
 
     class _FailingStore:
@@ -195,9 +204,14 @@ async def test_runtime_durable_lookup_failure_downgrades_to_fallback_once(
     assert len(fallback_lines) == 1
 
 
-def test_defaults_store_uses_graphiti_backend_selection(monkeypatch: pytest.MonkeyPatch) -> None:
+def test_defaults_store_uses_graphiti_backend_selection(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
     monkeypatch.setattr(
-        defaults_memory_mod.settings, "tasks_defaults_memory_backend", "graphiti", raising=False
+        defaults_memory_mod.settings,
+        "tasks_defaults_memory_backend",
+        "graphiti",
+        raising=False,
     )
     store = TaskDefaultsMemoryStore()
     sentinel_client = object()
@@ -213,7 +227,10 @@ def test_defaults_store_uses_graphiti_backend_selection(monkeypatch: pytest.Monk
         return sentinel_store
 
     monkeypatch.setattr(
-        defaults_memory_mod.settings, "timeboxing_memory_backend", "graphiti", raising=False
+        defaults_memory_mod.settings,
+        "timeboxing_memory_backend",
+        "graphiti",
+        raising=False,
     )
     monkeypatch.setattr(
         defaults_memory_mod.settings, "graphiti_user_id", "user-graphiti", raising=False
@@ -221,9 +238,14 @@ def test_defaults_store_uses_graphiti_backend_selection(monkeypatch: pytest.Monk
     monkeypatch.setattr(
         defaults_memory_mod, "build_graphiti_client_from_settings", _fake_build_graphiti
     )
-    monkeypatch.setattr(defaults_memory_mod, "build_durable_constraint_store", _fake_build_store)
+    monkeypatch.setattr(
+        defaults_memory_mod, "build_durable_constraint_store", _fake_build_store
+    )
 
     resolved = store._ensure_store()
+
+    assert resolved is sentinel_store
+    assert captured["user_id"] == "user-graphiti"
 
     assert resolved is sentinel_store
     assert captured["user_id"] == "user-graphiti"

--- a/tests/unit/test_timeboxing_constraint_extraction_background.py
+++ b/tests/unit/test_timeboxing_constraint_extraction_background.py
@@ -36,8 +36,15 @@ async def test_queue_constraint_extraction_runs_in_background():
             ],
         )
 
+    store_calls = {"replace": 0, "add": 0}
+
     class _Store:
+        async def replace_session_constraints(self, **_kwargs):
+            store_calls["replace"] += 1
+            return []
+
         async def add_constraints(self, **_kwargs):
+            store_calls["add"] += 1
             return []
 
     async def _fake_collect_constraints(_session: Session):
@@ -67,6 +74,8 @@ async def test_queue_constraint_extraction_runs_in_background():
     res = await asyncio.wait_for(task, timeout=1.0)
     assert res is not None
     assert not session.pending_constraint_extractions
+    assert store_calls["replace"] == 1
+    assert store_calls["add"] == 0
 
 
 @pytest.mark.asyncio

--- a/tests/unit/test_timeboxing_constraint_selection.py
+++ b/tests/unit/test_timeboxing_constraint_selection.py
@@ -22,6 +22,7 @@ def _constraint(
     name: str,
     uid: str,
     necessity: ConstraintNecessity = ConstraintNecessity.SHOULD,
+    scope: ConstraintScope = ConstraintScope.PROFILE,
 ) -> Constraint:
     return Constraint(
         name=name,
@@ -29,12 +30,43 @@ def _constraint(
         necessity=necessity,
         status=ConstraintStatus.LOCKED,
         source=ConstraintSource.USER,
-        scope=ConstraintScope.PROFILE,
+        scope=scope,
         hints={"uid": uid},
         user_id="u1",
         channel_id="c1",
         thread_ts="t1",
     )
+
+
+def _aspect_hints(
+    *,
+    aspect_id: str,
+    category: str,
+    frame_slot: str | None = None,
+    schedule_start: str | None = None,
+    schedule_end: str | None = None,
+    is_startup_prefetch: bool = False,
+    is_conditional: bool = False,
+    conditional_on_absent: list[str] | None = None,
+    conditional_on_present: list[str] | None = None,
+    excludes_aspect_ids: list[str] | None = None,
+) -> dict[str, object]:
+    return {
+        "aspect_classification": {
+            "aspect_id": aspect_id,
+            "aspect_label": aspect_id.replace("_", " ").title(),
+            "category": category,
+            "frame_slot": frame_slot,
+            "is_startup_prefetch": is_startup_prefetch,
+            "schedule_start": schedule_start,
+            "schedule_end": schedule_end,
+            "duration_min": None,
+            "is_conditional": is_conditional,
+            "conditional_on_absent": list(conditional_on_absent or []),
+            "conditional_on_present": list(conditional_on_present or []),
+            "excludes_aspect_ids": list(excludes_aspect_ids or []),
+        }
+    }
 
 
 @pytest.mark.asyncio
@@ -275,11 +307,271 @@ async def test_collect_constraints_reconciles_and_filters_stage_relevance() -> N
     assert "Session ask" in names
 
 
-def test_select_constraints_for_refine_patcher_caps_and_preserves_must() -> None:
+@pytest.mark.asyncio
+async def test_collect_constraints_prefers_session_activity_over_profile_default_time() -> None:
+    agent = TimeboxingFlowAgent.__new__(TimeboxingFlowAgent)
+    agent._constraint_store = None
+    session = Session(
+        thread_ts="t1",
+        channel_id="c1",
+        user_id="u1",
+        committed=True,
+        planned_date="2026-03-06",
+    )
+    session.stage = TimeboxingStage.REFINE
+    profile_default = Constraint(
+        user_id="u1",
+        channel_id=None,
+        thread_ts=None,
+        name="Default gym in evening",
+        description="Gym in the evening by default.",
+        necessity=ConstraintNecessity.SHOULD,
+        status=ConstraintStatus.LOCKED,
+        source=ConstraintSource.USER,
+        scope=ConstraintScope.PROFILE,
+        hints=_aspect_hints(
+            aspect_id="gym_training",
+            category="exercise",
+            schedule_start="18:00",
+            schedule_end="19:30",
+        ),
+    )
+    session_override = Constraint(
+        user_id="u1",
+        channel_id="c1",
+        thread_ts="t1",
+        name="Gym at noon",
+        description="Gym should be at 12:00 today.",
+        necessity=ConstraintNecessity.MUST,
+        status=ConstraintStatus.PROPOSED,
+        source=ConstraintSource.USER,
+        scope=ConstraintScope.SESSION,
+        hints=_aspect_hints(
+            aspect_id="gym_training",
+            category="exercise",
+            schedule_start="12:00",
+            schedule_end="13:30",
+        ),
+    )
+    session.durable_constraints_by_stage = {
+        TimeboxingStage.REFINE.value: [profile_default, session_override]
+    }
+
+    active = await TimeboxingFlowAgent._collect_constraints(agent, session)
+
+    assert [item.name for item in active] == ["Gym at noon"]
+
+
+@pytest.mark.asyncio
+async def test_collect_constraints_prefers_session_gym_and_planning_over_defaults() -> None:
+    agent = TimeboxingFlowAgent.__new__(TimeboxingFlowAgent)
+    agent._constraint_store = None
+    session = Session(
+        thread_ts="t1",
+        channel_id="c1",
+        user_id="u1",
+        committed=True,
+        planned_date="2026-03-06",
+    )
+    session.stage = TimeboxingStage.REFINE
+    session.durable_constraints_by_stage = {
+        TimeboxingStage.REFINE.value: [
+            Constraint(
+                user_id="u1",
+                channel_id=None,
+                thread_ts=None,
+                name="Default gym in evening",
+                description="Gym around 18:00",
+                necessity=ConstraintNecessity.SHOULD,
+                status=ConstraintStatus.PROPOSED,
+                source=ConstraintSource.USER,
+                scope=ConstraintScope.PROFILE,
+                hints=_aspect_hints(
+                    aspect_id="gym_training",
+                    category="exercise",
+                    schedule_start="18:00",
+                    schedule_end="19:30",
+                ),
+            ),
+            Constraint(
+                user_id="u1",
+                channel_id=None,
+                thread_ts=None,
+                name="Default planning slot",
+                description="Planning around 14:00",
+                necessity=ConstraintNecessity.SHOULD,
+                status=ConstraintStatus.PROPOSED,
+                source=ConstraintSource.USER,
+                scope=ConstraintScope.PROFILE,
+                hints=_aspect_hints(
+                    aspect_id="planning_session",
+                    category="work",
+                    schedule_start="14:00",
+                    schedule_end="15:00",
+                ),
+            ),
+            Constraint(
+                user_id="u1",
+                channel_id="c1",
+                thread_ts="t1",
+                name="Gym at noon",
+                description="Gym at 12:00 today.",
+                necessity=ConstraintNecessity.MUST,
+                status=ConstraintStatus.LOCKED,
+                source=ConstraintSource.USER,
+                scope=ConstraintScope.SESSION,
+                hints=_aspect_hints(
+                    aspect_id="gym_training",
+                    category="exercise",
+                    schedule_start="12:00",
+                    schedule_end="13:30",
+                ),
+            ),
+            Constraint(
+                user_id="u1",
+                channel_id="c1",
+                thread_ts="t1",
+                name="Planning at 16:00",
+                description="Planning session is at 16:00.",
+                necessity=ConstraintNecessity.MUST,
+                status=ConstraintStatus.LOCKED,
+                source=ConstraintSource.USER,
+                scope=ConstraintScope.SESSION,
+                hints=_aspect_hints(
+                    aspect_id="planning_session",
+                    category="work",
+                    schedule_start="16:00",
+                    schedule_end="17:00",
+                ),
+            ),
+        ]
+    }
+
+    active = await TimeboxingFlowAgent._collect_constraints(agent, session)
+    names = {item.name for item in active}
+
+    assert {"Gym at noon", "Planning at 16:00"}.issubset(names)
+    assert "Default gym in evening" not in names
+    assert "Default planning slot" not in names
+
+
+@pytest.mark.asyncio
+async def test_collect_constraints_suppresses_conditional_gym_when_other_sport_present() -> None:
+    agent = TimeboxingFlowAgent.__new__(TimeboxingFlowAgent)
+    agent._constraint_store = None
+    events: list[tuple[str, dict[str, object]]] = []
+    agent._session_debug = lambda _session, event, **kwargs: events.append((event, kwargs))
+    session = Session(
+        thread_ts="t1",
+        channel_id="c1",
+        user_id="u1",
+        committed=True,
+        planned_date="2026-03-06",
+    )
+    session.stage = TimeboxingStage.REFINE
+    conditional_gym = Constraint(
+        user_id="u1",
+        channel_id=None,
+        thread_ts=None,
+        name="Gym default",
+        description="Go to the gym unless another sport is already planned.",
+        necessity=ConstraintNecessity.SHOULD,
+        status=ConstraintStatus.LOCKED,
+        source=ConstraintSource.USER,
+        scope=ConstraintScope.PROFILE,
+        hints=_aspect_hints(
+            aspect_id="gym_training",
+            category="exercise",
+            schedule_start="18:00",
+            schedule_end="19:30",
+            is_conditional=True,
+            conditional_on_absent=["field_hockey"],
+        ),
+    )
+    hockey_today = Constraint(
+        user_id="u1",
+        channel_id="c1",
+        thread_ts="t1",
+        name="Field hockey tonight",
+        description="Playing field hockey tonight.",
+        necessity=ConstraintNecessity.MUST,
+        status=ConstraintStatus.PROPOSED,
+        source=ConstraintSource.USER,
+        scope=ConstraintScope.SESSION,
+        hints=_aspect_hints(
+            aspect_id="field_hockey",
+            category="exercise",
+            schedule_start="19:00",
+            schedule_end="21:00",
+            excludes_aspect_ids=["gym_training"],
+        ),
+    )
+    session.durable_constraints_by_stage = {
+        TimeboxingStage.REFINE.value: [conditional_gym, hockey_today]
+    }
+
+    active = await TimeboxingFlowAgent._collect_constraints(agent, session)
+
+    assert [item.name for item in active] == ["Field hockey tonight"]
+    snapshots = [payload for event, payload in events if event == "constraints_active_snapshot"]
+    assert snapshots, "Expected constraints_active_snapshot debug event."
+    assert snapshots[-1]["active_suppressed_count"] == 1
+    assert snapshots[-1]["active_suppressed_reasons"] == ["conditional_on_absent"]
+
+
+@pytest.mark.asyncio
+async def test_collect_constraints_keeps_conditional_gym_without_blocker() -> None:
+    agent = TimeboxingFlowAgent.__new__(TimeboxingFlowAgent)
+    agent._constraint_store = None
+    session = Session(
+        thread_ts="t1",
+        channel_id="c1",
+        user_id="u1",
+        committed=True,
+        planned_date="2026-03-06",
+    )
+    session.stage = TimeboxingStage.REFINE
+    conditional_gym = Constraint(
+        user_id="u1",
+        channel_id=None,
+        thread_ts=None,
+        name="Gym default",
+        description="Go to the gym unless another sport is already planned.",
+        necessity=ConstraintNecessity.SHOULD,
+        status=ConstraintStatus.LOCKED,
+        source=ConstraintSource.USER,
+        scope=ConstraintScope.PROFILE,
+        hints=_aspect_hints(
+            aspect_id="gym_training",
+            category="exercise",
+            schedule_start="18:00",
+            schedule_end="19:30",
+            is_conditional=True,
+            conditional_on_absent=["field_hockey"],
+        ),
+    )
+    session.durable_constraints_by_stage = {
+        TimeboxingStage.REFINE.value: [conditional_gym]
+    }
+
+    active = await TimeboxingFlowAgent._collect_constraints(agent, session)
+
+    assert [item.name for item in active] == ["Gym default"]
+
+
+def test_select_constraints_for_refine_patcher_keeps_all_session_and_caps_durable() -> None:
     agent = TimeboxingFlowAgent.__new__(TimeboxingFlowAgent)
     session = Session(thread_ts="t1", channel_id="c1", user_id="u1", committed=True)
     session.stage = TimeboxingStage.REFINE
-    constraints = [
+    session_constraints = [
+        _constraint(
+            name=f"session-{idx}",
+            uid=f"session-{idx}",
+            scope=ConstraintScope.SESSION,
+        )
+        for idx in range(3)
+    ]
+    durable_constraints = [
         _constraint(
             name=f"must-{idx}",
             uid=f"must-{idx}",
@@ -290,6 +582,7 @@ def test_select_constraints_for_refine_patcher_caps_and_preserves_must() -> None
         _constraint(name=f"should-{idx}", uid=f"should-{idx}")
         for idx in range(TIMEBOXING_LIMITS.refine_patcher_constraint_limit + 20)
     ]
+    constraints = [*session_constraints, *durable_constraints]
 
     selected = TimeboxingFlowAgent._select_constraints_for_refine_patcher(
         agent,
@@ -297,5 +590,10 @@ def test_select_constraints_for_refine_patcher_caps_and_preserves_must() -> None
         constraints=constraints,
     )
 
-    assert len(selected) == TIMEBOXING_LIMITS.refine_patcher_constraint_limit
+    assert len(selected) == (
+        len(session_constraints) + TIMEBOXING_LIMITS.refine_patcher_constraint_limit
+    )
+    assert {item.name for item in session_constraints}.issubset(
+        {item.name for item in selected}
+    )
     assert {"must-0", "must-1"}.issubset({item.name for item in selected})

--- a/tests/unit/test_timeboxing_constraint_store_canonicalization.py
+++ b/tests/unit/test_timeboxing_constraint_store_canonicalization.py
@@ -160,3 +160,53 @@ async def test_prune_shared_constraints_apply_keeps_single_canonical_row() -> No
         assert remaining[0].status == ConstraintStatus.LOCKED
     finally:
         await engine.dispose()
+
+
+@pytest.mark.asyncio
+async def test_replace_session_constraints_replaces_thread_snapshot() -> None:
+    engine = create_async_engine("sqlite+aiosqlite:///:memory:")
+    try:
+        await ensure_constraint_schema(engine)
+        store = ConstraintStore(async_sessionmaker(engine, expire_on_commit=False))
+        await store.add_constraints(
+            user_id="u1",
+            channel_id="c1",
+            thread_ts="t1",
+            constraints=[
+                ConstraintBase(
+                    name="Old session rule",
+                    description="legacy",
+                    necessity=ConstraintNecessity.SHOULD,
+                    status=ConstraintStatus.PROPOSED,
+                    source=ConstraintSource.USER,
+                    scope=ConstraintScope.SESSION,
+                )
+            ],
+        )
+        replaced = await store.replace_session_constraints(
+            user_id="u1",
+            channel_id="c1",
+            thread_ts="t1",
+            constraints=[
+                ConstraintBase(
+                    name="New session rule",
+                    description="fresh",
+                    necessity=ConstraintNecessity.MUST,
+                    status=ConstraintStatus.LOCKED,
+                    source=ConstraintSource.USER,
+                    scope=ConstraintScope.SESSION,
+                )
+            ],
+        )
+        rows = await store.list_constraints(
+            user_id="u1",
+            channel_id="c1",
+            thread_ts="t1",
+            scope=ConstraintScope.SESSION,
+        )
+
+        assert len(replaced) == 1
+        assert len(rows) == 1
+        assert rows[0].name == "New session rule"
+    finally:
+        await engine.dispose()

--- a/tests/unit/test_timeboxing_durable_constraints.py
+++ b/tests/unit/test_timeboxing_durable_constraints.py
@@ -133,7 +133,7 @@ async def test_collect_constraints_merges_durable_with_session():
 async def test_collect_constraints_requests_shared_scope_fallback(monkeypatch) -> None:
     agent = TimeboxingFlowAgent.__new__(TimeboxingFlowAgent)
     captured_kwargs: list[dict[str, object]] = []
-    monkeypatch.setattr(settings, "timeboxing_memory_backend", "constraint_mcp")
+    monkeypatch.setattr(settings, "timeboxing_memory_backend", "graphiti")
 
     class _Store:
         async def list_constraints(self, **kwargs):

--- a/tests/unit/test_timeboxing_memory_backend_selection.py
+++ b/tests/unit/test_timeboxing_memory_backend_selection.py
@@ -74,15 +74,12 @@ def test_ensure_constraint_memory_client_stops_retrying_after_failure(monkeypatc
     assert "RuntimeError" in (agent._constraint_memory_unavailable_reason or "")
 
 
-def test_ensure_constraint_memory_client_uses_constraint_mcp_backend(
+def test_ensure_constraint_memory_client_rejects_legacy_backend(
     monkeypatch,
 ) -> None:
     agent = TimeboxingFlowAgent.__new__(TimeboxingFlowAgent)
     agent._constraint_memory_client = None
     agent._constraint_memory_unavailable_reason = None
-
-    sentinel = object()
-    captured: dict[str, float] = {}
 
     monkeypatch.setattr(
         timeboxing_agent_mod.settings,
@@ -90,22 +87,13 @@ def test_ensure_constraint_memory_client_uses_constraint_mcp_backend(
         "constraint_mcp",
         raising=False,
     )
-    monkeypatch.setattr(
-        timeboxing_agent_mod.settings,
-        "agent_mcp_discovery_timeout_seconds",
-        12,
-        raising=False,
-    )
-    def _fake_constraint_client(*, timeout: float):
-        captured["timeout"] = timeout
-        return sentinel
-
-    monkeypatch.setattr(timeboxing_agent_mod, "ConstraintMemoryClient", _fake_constraint_client)
 
     client = TimeboxingFlowAgent._ensure_constraint_memory_client(agent)
 
-    assert client is sentinel
-    assert captured["timeout"] == 12.0
+    assert client is None
+    assert "unsupported timeboxing memory backend" in (
+        agent._constraint_memory_unavailable_reason or ""
+    ).lower()
 
 
 def test_queue_durable_constraint_upsert_queues_without_parent_config(

--- a/tests/unit/test_timeboxing_stage_actions.py
+++ b/tests/unit/test_timeboxing_stage_actions.py
@@ -310,6 +310,7 @@ def test_render_constraints_preview_blocks_labels_new_active_and_selected_counts
     assert "Newly extracted: 6." in preview_text
     assert "Active total (applicable now): 6." in preview_text
     assert "Selected for Refine patching: 4." in preview_text
+    assert "Conflict resolution: kept 4, overridden 2." in preview_text
     assert "Showing the top 3 of 6." in preview_text
 
 

--- a/tests/unit/test_timeboxing_stateless_agents.py
+++ b/tests/unit/test_timeboxing_stateless_agents.py
@@ -43,6 +43,13 @@ import fateforger.agents.timeboxing.agent as agent_mod
 import fateforger.agents.timeboxing.nlu as nlu_mod
 from fateforger.agents.timeboxing.agent import Session, TimeboxingFlowAgent
 from fateforger.agents.timeboxing.nlu import MemoryReviewDecision
+from fateforger.agents.timeboxing.preferences import (
+    Constraint,
+    ConstraintNecessity,
+    ConstraintScope,
+    ConstraintSource,
+    ConstraintStatus,
+)
 from fateforger.agents.timeboxing.stage_gating import StageDecision, StageGateOutput
 
 # ---------------------------------------------------------------------------
@@ -335,6 +342,58 @@ class TestInterpretConstraintsStateless:
             assert (
                 len(inst.calls[0]) == 1
             ), f"Agent {i} should receive exactly 1 message"
+
+    @pytest.mark.asyncio
+    async def test_payload_includes_existing_session_constraints(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        result_json = json.dumps(
+            {
+                "constraints": [],
+                "scope": "session",
+                "should_extract": False,
+            }
+        )
+        counter = _InstantiationCounter(response_content=result_json)
+
+        def _factory(*, model_client: Any) -> _FakeAgent:  # noqa: ANN401
+            return counter.make_agent(model_client=model_client)
+
+        monkeypatch.setattr(agent_mod, "build_constraint_interpreter", _factory)
+
+        agent = _make_agent(model_client=object())
+        existing = Constraint(
+            user_id="u1",
+            channel_id="c1",
+            thread_ts="t1",
+            name="Gym at noon",
+            description="Keep gym around 12:00.",
+            necessity=ConstraintNecessity.SHOULD,
+            status=ConstraintStatus.PROPOSED,
+            source=ConstraintSource.USER,
+            scope=ConstraintScope.SESSION,
+            hints={"uid": "gym-noon"},
+        )
+
+        class _Store:
+            async def list_constraints(self, **kwargs: Any) -> list[Constraint]:  # noqa: ANN401
+                assert kwargs["scope"] == ConstraintScope.SESSION
+                return [existing]
+
+        async def _noop_store() -> None:
+            return None
+
+        agent._ensure_constraint_store = _noop_store  # type: ignore[assignment]
+        agent._constraint_store = _Store()
+        session = Session(thread_ts="t1", channel_id="c1", user_id="u1")
+
+        await agent._interpret_constraints(
+            session, text="move gym a bit later", is_initial=False
+        )
+
+        payload = json.loads(counter.instances[0].calls[0][0].content)
+        assert payload["existing_constraints"]
+        assert payload["existing_constraints"][0]["name"] == "Gym at noon"
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
- Update .github/ chat modes (architect, ask, code, debug) to AGENTS.md-first pattern; remove MemoriPilot references
- Update copilot-instructions.md: AGENTS.md-first directive + working-mode hints
- Update blog post: add memory-bank-goes-stale argument + In-Context Learning subtitle
- Fix defaults_memory.py: add "graphiti" to _TASK_DEFAULTS_BACKENDS
- Fix preferences.py: remove dead delete-based prune_shared_constraints; restore archive-based (issue/81) as the single canonical impl
- Fix agent.py: use duplicates_archived key consistent with archive impl
- Fix test_planning_reminder_suppression: use date.today() not hardcoded 2026-03-07
- Fix test_task_defaults_memory: migrate mem0 build test to graphiti path
- Fix test_timeboxing_constraint_store_canonicalization: direct DB inserts for dirty-state setup; assertions aligned to archive API
- Add test_review_commit_template_includes_submit_button_guidance (merged from stash)
- Update .env: TIMEBOXING_MEMORY_BACKEND=graphiti

## Linked issue

- GitHub issue: <!-- required -->
- Issue branch: <!-- e.g. issue/123-notebook-workflow -->

## Acceptance criteria

- [ ] Criterion 1:
- [ ] Criterion 2:
- [ ] Criterion 3:

## Notebook -> artifact mapping (required for notebook-driven work)

- Primary notebook path:
- Notebook lifecycle status (`WIP` / `Extraction complete` / `DONE` / `Reference` / `Archived`):
- Extracted implementation files (`src/...`):
- Extracted test files (`tests/...`):
- Extracted docs (`README.md` / `docs/...`):
- Intentionally retained notebook-only content (and why):

## Verification performed

- [ ] Start-of-work cleanliness check recorded (`git status --porcelain`)
- [ ] Pre-PR-close cleanliness check recorded (`git status --porcelain`)
- [ ] Relevant automated tests passed
- [ ] Notebook checkpoint passed (clean-kernel rerun or CI notebook check)

Commands run:

```bash
# paste commands used for verification
```

## System-of-record sync

- [ ] Issue status updated
- [ ] PR description reflects current implementation status
- [ ] Temporary `/tickets/` markdown removed or explicitly retained as durable documentation
